### PR TITLE
[#171324301] Added CD to azure devops pipeline

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,0 +1,7 @@
+*.js.map
+*.ts
+.vscode
+.git
+local.settings.json
+test
+tsconfig.json

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,28 +1,51 @@
-# Azure DevOps pipeline to build, check source codes, run tests, and more.
+# Azure DevOps pipeline to build, check source codes, run tests, and deploy.
 #
+# The following variables needs to be defined before running the deployment jobs 
+# defined in this pipeline:
+# - STAGING_AZURE_SUBSCRIPTION
+# - STAGING_RESOURCE_GROUP_NAME
+# - STAGING_FUNCTION_APP_NAME
+# - PRODUCTION_AZURE_SUBSCRIPTION
+# - PRODUCTION_RESOURCE_GROUP_NAME
+# - PRODUCTION_FUNCTION_APP_NAME
+#
+# To enable the deployment and define if using deployment slots you also need to 
+# configure these variables:
+# - DO_DEPLOY: if False or undefined all deployments are skipped
+# - DEPLOY_TO_SLOT: if True the deployment to slot is performed
+
+variables:
+  NODE_VERSION: '10.14.1'
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
+# This pipeline can be manually run or is automatically triggered whenever one 
+# of the following condition is true:
+# - a push is made to any branch in the repository (not only 'master')
+# - a pull request is created
+# - a tag named 'latest' is pushed
+# Note. In the last case, the tag can be (re-)created using the Git CLI, e.g.:
+#    git push -f origin <abfb967>:refs/tags/latest
+trigger:
+  branches:
+    include:
+      - '*'
+      - refs/tags/latest
+
 # This pipeline has been implemented to be run on hosted agent pools based both
 # on 'windows' and 'ubuntu' virtual machine images and using the scripts defined
 # in the package.json file. Since we are deploying on Azure functions on Windows
 # runtime, the pipeline is currently configured to use a Windows hosted image.
-
-variables:
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-
 pool:
   vmImage: 'windows-2019'
 
 stages:
-  # A) Install modules and build
-  - stage: Build_check
+  # A) Build and code validation
+  - stage: Build
     dependsOn: []
     jobs:
-      - job: compile
+      # A1) Checkout, install module and build distribution artifacts
+      - job: make_build
         steps:
-        - task: NodeTool@0
-          inputs:
-            versionSpec: '10.14.1'
-          displayName: 'Install Node.js'
-        
         - task: Cache@2
           inputs:
             key: 'yarn | "$(Agent.OS)" | yarn.lock'
@@ -30,24 +53,38 @@ stages:
               yarn | "$(Agent.OS)"
               yarn
             path: $(YARN_CACHE_FOLDER)
-          displayName: Cache Yarn packages
+          displayName: Cache yarn packages
 
         - script: |
             yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
           displayName: 'Install node modules'
 
         - bash: |
-            yarn build
-          displayName: 'Build'
+            yarn predeploy
+          displayName: 'Build distribution'
 
+        # Publish the build artifacts only if deployment is not skipped.
+        # The '.artifactignore' file is used to control what files are uploaded
+        - task: PublishPipelineArtifact@1
+          condition: and(
+              succeeded(),
+              and (
+                eq(variables['DO_DEPLOY'], True),
+                or(
+                  eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+                  eq(variables['Build.SourceBranch'], 'refs/tags/latest')
+                )
+              )
+            )
+          inputs:
+            targetPath: $(System.DefaultWorkingDirectory)/
+            artifact: 'dist'
+            publishLocation: 'pipeline'
+          displayName: Publish build artifacts
 
-  # B) Checker and validator tools for static code analysis
-  - stage: Source_check
-    dependsOn: []
-    jobs:
-      # B1) Analyze source code to find errors
+      # A2) Analyze source code to find errors with lint
       - job: lint
-        steps:
+        steps:        
         - task: Cache@2
           inputs:
             key: 'yarn | "$(Agent.OS)" | yarn.lock'
@@ -55,7 +92,7 @@ stages:
               yarn | "$(Agent.OS)"
               yarn
             path: $(YARN_CACHE_FOLDER)
-          displayName: Cache Yarn packages
+          displayName: Cache yarn packages
 
         - script: |
             yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
@@ -65,16 +102,21 @@ stages:
             yarn lint
           displayName: 'Lint'
 
-      # B2) Validate API definition 
+      # A3) Validate API definition
       - job: lint_api
         steps:
         - script: |
             npx oval validate -p openapi/index.yaml
-          displayName: 'Validate OpenAPI'
+          displayName: 'Validate openAPI'
 
-      # B3) Check source code with danger (only when there is a PR)
+      # A4) Check source code with danger (ignore when master)
       - job: danger
-        condition: variables['DANGER_GITHUB_API_TOKEN']
+        condition: and(succeeded(),
+            and(
+              variables['DANGER_GITHUB_API_TOKEN'], 
+              ne(variables['Build.SourceBranch'], 'refs/heads/master')
+            )
+          )
         steps:
         - task: Cache@2
           inputs:
@@ -83,7 +125,7 @@ stages:
               yarn | "$(Agent.OS)"
               yarn
             path: $(YARN_CACHE_FOLDER)
-          displayName: Cache Yarn packages
+          displayName: Cache yarn packages
 
         - script: |
             yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
@@ -94,12 +136,17 @@ stages:
           displayName: 'Danger CI'
 
 
-  # C) Run unit tests
-  - stage: Tests_check
+  # B) Run unit tests if there is a push or pull request on any branch.
+  - stage: Test
     dependsOn: []
     jobs:
       - job: unit_tests
         steps:
+        - task: UseNode@1
+          inputs:
+            version: $(NODE_VERSION)
+          displayName: 'Set up Node.js'
+
         - task: Cache@2
           inputs:
             key: 'yarn | "$(Agent.OS)" | yarn.lock'
@@ -107,7 +154,7 @@ stages:
               yarn | "$(Agent.OS)"
               yarn
             path: $(YARN_CACHE_FOLDER)
-          displayName: Cache Yarn packages
+          displayName: Cache yarn packages
 
         - script: |
             yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
@@ -120,3 +167,146 @@ stages:
         - bash: |
             bash <(curl -s https://codecov.io/bash)
           displayName: 'Code coverage'
+
+
+  # C) Deploy to STAGING only if there is a push on 'master' branch.
+  # Other conditions based on variables settings:
+  # - if $DO_DEPLOY != True (or undefined) skip deployment, otherwise:
+  #   - c1) $DEPLOY_TO_SLOT != True (or undefined): deploy to STAGING environment
+  #   - c2) $DEPLOY_TO_SLOT == True: deploy to staging slot in PROD environment
+  - stage: Deploy_staging
+    condition: and(succeeded(),
+        and(
+          eq(variables['DO_DEPLOY'], True), 
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        )
+      )
+    dependsOn:
+    - Build
+    - Test
+    jobs:
+      - job: deploy_to_staging
+        steps:
+        - checkout: none
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'current'
+            artifactName: 'dist'
+            targetPath: '$(System.DefaultWorkingDirectory)'
+          displayName: 'Download build artifacts'
+
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: '$(System.DefaultWorkingDirectory)'
+            includeRootFolder: false
+            archiveType: 'zip'
+            archiveFile: 'dist.zip'
+          displayName: 'Make deployment zip'
+
+        # c1) First option: standard deployment in STAGING env (without slots)
+        - task: AzureFunctionApp@1
+          condition: and(succeeded(), ne(variables['DEPLOY_TO_SLOT'], True))
+          inputs:
+            azureSubscription: '$(STAGING_AZURE_SUBSCRIPTION)'
+            resourceGroupName: '$(STAGING_RESOURCE_GROUP_NAME)'
+            appType: 'functionApp'
+            appName: '$(STAGING_FUNCTION_APP_NAME)'
+            package: '$(System.DefaultWorkingDirectory)/dist.zip'
+            deploymentMethod: 'auto'
+          displayName: Deploy to staging env
+
+        # c2) Alternative option: deployment to 'staging' slot in PROD env.
+        # Note. Deployment slots let you deploy different versions of your function
+        # app to different URLs. You can test a certain version and then swap content
+        # and configuration between slots.
+        - task: AzureFunctionApp@1
+          condition: and(succeeded(), eq(variables['DEPLOY_TO_SLOT'], True))
+          inputs:
+            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+            resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+            appType: 'functionApp'
+            appName: '$(PRODUCTION_FUNCTION_APP_NAME)'
+            package: '$(System.DefaultWorkingDirectory)/dist.zip'
+            deploymentMethod: 'auto'
+            deployToSlotOrASE: true
+            slotName: 'staging'
+          displayName: Deploy to staging slot in prod env
+
+
+  # D) Deploy to PRODUCTION only if the 'latest' tag is pushed.
+  # Other conditions based on variables settings:
+  # - if $DO_DEPLOY != True (or undefined) skip deployment, otherwise:
+  #   - d1) $DEPLOY_TO_SLOT != True (or undefined): deploy to PROD environment
+  #   - d2) $DEPLOY_TO_SLOT == True: deploy to 'staging' slot in PROD environment
+  #         and then swap 'staging' slot with 'production' slot
+  - stage: Deploy_production
+    condition: and(succeeded(),
+        and(
+          eq(variables['DO_DEPLOY'], true), 
+          eq(variables['Build.SourceBranch'], 'refs/tags/latest')
+        )
+      )
+    dependsOn:
+    - Build
+    - Test
+    jobs:
+      - job: deploy_to_production
+        steps:
+        - checkout: none
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'current'
+            artifactName: 'dist'
+            targetPath: '$(System.DefaultWorkingDirectory)'
+          displayName: 'Download build artifacts'
+
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: '$(System.DefaultWorkingDirectory)'
+            includeRootFolder: false
+            archiveType: 'zip'
+            archiveFile: 'dist.zip'
+          displayName: 'Make deployment zip'
+
+        # d1) First option: standard deployment in PROD (without swapping slots)
+        - task: AzureFunctionApp@1
+          condition: and(succeeded(), ne(variables['DEPLOY_TO_SLOT'], True))
+          inputs:
+            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+            resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+            appType: 'functionApp'
+            appName: '$(PRODUCTION_FUNCTION_APP_NAME)'
+            package: '$(System.DefaultWorkingDirectory)/dist.zip'
+            deploymentMethod: 'auto'
+          displayName: Deploy to production env
+
+        # d2) Alternative option: deployment in PROD using slots.
+
+        # d2-I) Deployment to 'staging' slot in PROD environment.
+        # Note. The deployment to 'staging' slot is done to be sure that the code
+        # tagged 'latest' is the ones that will be swapped to be deployed in Prod...
+        - task: AzureFunctionApp@1
+          condition: and(succeeded(), eq(variables['DEPLOY_TO_SLOT'], True))
+          inputs:
+            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+            resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+            appType: 'functionApp'
+            appName: '$(PRODUCTION_FUNCTION_APP_NAME)'
+            package: '$(System.DefaultWorkingDirectory)/dist.zip'
+            deploymentMethod: 'auto'
+            deployToSlotOrASE: true
+            slotName: 'staging'
+          displayName: Deploy to staging slot
+
+        # d2-II) Swap 'staging' with 'production' slot in PROD env.
+        - task: AzureAppServiceManage@0
+          condition: and(succeeded(), eq(variables['DEPLOY_TO_SLOT'], True))
+          inputs:
+            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+            WebAppName: '$(PRODUCTION_FUNCTION_APP_NAME)'
+            ResourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+            SourceSlot: staging
+            SwapWithProduction: true
+          displayName: Swap with production slot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,10 @@ variables:
 # - a tag named 'latest' is pushed
 # Note. In the last case, the tag can be (re-)created using the Git CLI, e.g.:
 #    git push -f origin <abfb967>:refs/tags/latest
+# To force the deployment regardless the above conditions you must configure the
+# following additional variables:
+# - STAGING_FORCE_DEPLOY: True
+# - PRODUCTION_FORCE_DEPLOY: True
 trigger:
   branches:
     include:
@@ -72,7 +76,8 @@ stages:
                 eq(variables['DO_DEPLOY'], True),
                 or(
                   eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-                  eq(variables['Build.SourceBranch'], 'refs/tags/latest')
+                  eq(variables['Build.SourceBranch'], 'refs/tags/latest'),
+                  eq(variables['STAGING_FORCE_DEPLOY'], True)
                 )
               )
             )
@@ -175,10 +180,14 @@ stages:
   #   - c1) $DEPLOY_TO_SLOT != True (or undefined): deploy to STAGING environment
   #   - c2) $DEPLOY_TO_SLOT == True: deploy to staging slot in PROD environment
   - stage: Deploy_staging
-    condition: and(succeeded(),
-        and(
-          eq(variables['DO_DEPLOY'], True), 
-          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(
+        succeeded(),
+        and (
+          eq(variables['DO_DEPLOY'], True),
+          or(
+            eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+            eq(variables['STAGING_FORCE_DEPLOY'], True)
+          )
         )
       )
     dependsOn:
@@ -241,10 +250,14 @@ stages:
   #   - d2) $DEPLOY_TO_SLOT == True: deploy to 'staging' slot in PROD environment
   #         and then swap 'staging' slot with 'production' slot
   - stage: Deploy_production
-    condition: and(succeeded(),
-        and(
-          eq(variables['DO_DEPLOY'], true), 
-          eq(variables['Build.SourceBranch'], 'refs/tags/latest')
+    condition: and(
+        succeeded(),
+        and (
+          eq(variables['DO_DEPLOY'], True),
+          or(
+            eq(variables['Build.SourceBranch'], 'refs/tags/latest'),
+            eq(variables['PRODUCTION_FORCE_DEPLOY'], True)
+          )
         )
       )
     dependsOn:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:coverage": "dotenv -e env.example -- jest --coverage",
     "lint": "tslint -p .",
     "deploy": "npm run build && func azure functionapp publish agid-functions-admin-test",
-    "generate:definitions": "rimraf ./generated/definitions && shx mkdir -p ./generated/definitions && gen-api-models --api-spec ./openapi/index.yaml --out-dir ./generated/definitions"
+    "generate:definitions": "rimraf ./generated/definitions && shx mkdir -p ./generated/definitions && gen-api-models --api-spec ./openapi/index.yaml --out-dir ./generated/definitions",
+    "dist:modules": "modclean -r -n default:safe && npm prune --production",
+    "predeploy": "npm-run-all build dist:modules"
   },
   "description": "",
   "devDependencies": {
@@ -34,6 +36,7 @@
     "jest": "^24.8.0",
     "jest-mock-express": "^0.1.1",
     "lolex": "^5.1.2",
+    "modclean": "^3.0.0-beta.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "shx": "^0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,6 +914,11 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+await-handler@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/await-handler/-/await-handler-1.1.2.tgz#329c19e9382599898bc12c80c47efdcdaa1b4992"
+  integrity sha512-dihteGhwbJpT89kVbacWiyKeAZr+En0YGK6pAKQJLR0En9ZxSH2H4TTvfG4bBjzFq9gDAma4y9BrpDns6j5UiQ==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -1421,7 +1426,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1512,6 +1517,18 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-spinners@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
+  integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -1544,6 +1561,11 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 cls-hooked@^4.2.2:
   version "4.2.2"
@@ -1650,7 +1672,7 @@ commander@^2.7.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.1.tgz#3863ce3ca92d0831dcf2a102f5fb4b5926afd0f9"
   integrity sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==
 
-commander@~2.20.3:
+commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1939,6 +1961,13 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2151,6 +2180,11 @@ emitter-listener@^1.0.1, emitter-listener@^1.1.1:
   dependencies:
     shimmer "^1.2.0"
 
+empty-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/empty-dir/-/empty-dir-1.0.0.tgz#be3ea41ca6798dc27bb9407f035888150e4c2995"
+  integrity sha512-97qcDM6mUA1jAeX6cktw7akc5awIGA+VIkA5MygKOKA+c2Vseo/xwKN0JNJTUhZUtPwZboKVD2p1xu+sV/F4xA==
+
 enabled@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
@@ -2221,6 +2255,11 @@ es6-object-assign@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
+es6-promise@^3.0.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -4800,10 +4839,22 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
 lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
 
 logform@^2.1.1:
   version "2.1.2"
@@ -5120,6 +5171,28 @@ mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+modclean-patterns-default@latest:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/modclean-patterns-default/-/modclean-patterns-default-1.1.2.tgz#9b2d53e3abd707edcf0c1501b4d5ac04c947a283"
+  integrity sha512-h2+ES3SKl+JOtfptJjwJz5fdogFI0byYssw3lXoESNkOcXCnjCvvW6IbMagAKFmfWOx+n9esyomxWP1w4edZjg==
+
+modclean@^3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/modclean/-/modclean-3.0.0-beta.1.tgz#34acdd610f130c2a833dc254486e2a260006d5bf"
+  integrity sha512-NyJpuqXMUI190sZePU+dBcwlGaqhfFC+UL5WyNSxmNLOHATg9cVSgRpbY+mUbwUj7t5trb4vYscgXArKevYsdA==
+  dependencies:
+    await-handler "^1.1.0"
+    chalk "^2.4.1"
+    commander "^2.9.0"
+    empty-dir "^1.0.0"
+    glob "^7.1.2"
+    lodash.uniq "^4.5.0"
+    modclean-patterns-default latest
+    ora "^2.1.0"
+    progress "^2.0.0"
+    rimraf "^2.5.4"
+    subdirs "^1.0.1"
 
 morgan@^1.9.1:
   version "1.9.1"
@@ -5470,6 +5543,13 @@ one-time@0.0.4:
   resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
   integrity sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
+
 ono@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ono/-/ono-5.1.0.tgz#8cafa7e56afa2211ad63dd2eb798427e64f1a070"
@@ -5508,6 +5588,18 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+ora@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-2.1.0.tgz#6caf2830eb924941861ec53a173799e008b51e5b"
+  integrity sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==
+  dependencies:
+    chalk "^2.3.1"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.1.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^4.0.0"
+    wcwidth "^1.0.1"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -5896,6 +5988,11 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
   version "2.1.0"
@@ -6355,6 +6452,14 @@ resolve@^1.2.0:
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -6862,6 +6967,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+subdirs@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/subdirs/-/subdirs-1.0.1.tgz#d65264787476e4caf7efc5498fb740c69f626d48"
+  integrity sha1-1lJkeHR25Mr378VJj7dAxp9ibUg=
+  dependencies:
+    es6-promise "^3.0.2"
 
 superagent@^3.8.3:
   version "3.8.3"
@@ -7555,6 +7667,13 @@ watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
   integrity sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Some notes about the changes:
- file `azure-pipelines.yaml`: 
-- added two new 'pipeline stages' (`Deploy_production` and `Deploy_staging`) to the Azure DevOps pipeline to manage the deployment of the Function app (see attached screenshot);   
-- all the deployment jobs are disabled by default, to enable them the following variable need to be defined and configured in the Azure pipeline (e.g. using web portal): `DO_DEPLOY: True`
-- two alternative deployment methods are supported: using slots or without slots (you can select the preferred method setting the variable `DEPLOY_TO_SLOT`)  
-- if enabled and all checks are passed (build, lint, lint_api, unit_test, etc.) the deployment in the staging environment is performed when there is a push on 'master' branch; the deployment in production only when a the tag `latest` is pushed 

- file `.artifactignore` has been added because this is the (only) Azure DevOps supported file to define the files and directories to be ignored when publishing the files to be used in the distribution (e.g. with PublishPipelineArtifact@1 task)... I also noticed that the command `zip` is not supported in the Windows agent of Azure DevOps (so it cannot be used with options `--exclude .funcignore` when creating the ZIP)
- file `package.json` has been modified to add some new scripts used for building the distribution files to be deployed (following suggestions in https://github.com/pagopa/io-functions-template): 
    "dist:modules": "modclean -r -n default:safe && npm prune --production":
    "predeploy": "npm-run-all build dist:modules"
- file `yarn.lock`: changed to add packages for `modclean` and `npm-run-all`

<img width="552" alt="Screenshot 2020-02-22 at 17 49 35" src="https://user-images.githubusercontent.com/60641726/75146382-42758700-56fb-11ea-9cd6-7445cf0c1f43.png">
