### PR TITLE
[#171784612] Fix parameters definition for uploadServiceLogo operation

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -103,13 +103,14 @@ paths:
         type: string
         required: true
         description: The ID of a existing Service.
-      - name: body
-        in: body
-        required: true
-        schema:
-          $ref: "#/definitions/Logo"
-        description: The logo payload
     put:
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/Logo"
+          description: The logo payload
       responses:
         "201":
           description: Logo uploaded.


### PR DESCRIPTION
This PR aims to fix the definition of the uploadServiceLogo operation in specs file in order to allow the generation of its correct request type by `io-utils`