### PR TITLE
[#171890372] Remove azure user attributes middleware

### DIFF
--- a/CreateService/__tests__/handler.test.ts
+++ b/CreateService/__tests__/handler.test.ts
@@ -44,8 +44,6 @@ describe("CreateServiceHandler", () => {
     const response = await createServiceHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServicePayload
     );
 
@@ -72,8 +70,6 @@ describe("CreateServiceHandler", () => {
     );
 
     const response = await createServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload
@@ -110,8 +106,6 @@ describe("CreateServiceHandler", () => {
 
     await createServiceHandler(
       contextMock as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload
     );

--- a/CreateSubscription/__tests__/handler.test.ts
+++ b/CreateSubscription/__tests__/handler.test.ts
@@ -106,8 +106,6 @@ describe("CreateSubscription", () => {
     const response = await createSubscriptionHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeParams as any,
       fakePayload as any
     );
@@ -127,8 +125,6 @@ describe("CreateSubscription", () => {
     const response = await createSubscriptionHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeParams as any,
       fakePayload as any
     );
@@ -145,8 +141,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any
@@ -166,8 +160,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any
@@ -191,8 +183,6 @@ describe("CreateSubscription", () => {
     const response = await createSubscriptionHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeParams as any,
       fakePayload as any
     );
@@ -213,8 +203,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any
@@ -237,8 +225,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any
@@ -265,8 +251,6 @@ describe("CreateSubscription", () => {
     const response = await createSubscriptionHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeParams as any,
       fakePayload as any
     );
@@ -291,8 +275,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any
@@ -319,8 +301,6 @@ describe("CreateSubscription", () => {
 
     const response = await createSubscriptionHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeParams as any,
       fakePayload as any

--- a/CreateSubscription/handler.ts
+++ b/CreateSubscription/handler.ts
@@ -1,7 +1,6 @@
 import { Context } from "@azure/functions";
 import * as express from "express";
 import { fromEither, fromPredicate, tryCatch } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -211,7 +210,6 @@ export function CreateSubscriptionHandler(
  * Wraps a CreateSubscription handler inside an Express request handler.
  */
 export function CreateSubscription(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): express.RequestHandler {

--- a/CreateSubscription/index.ts
+++ b/CreateSubscription/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { CreateSubscription } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -60,7 +37,7 @@ secureExpressApp(app);
 // Add express route
 app.put(
   "/adm/users/:email/subscriptions/:subscriptionId",
-  CreateSubscription(serviceModel, servicePrincipalCreds, azureApimConfig)
+  CreateSubscription(servicePrincipalCreds, azureApimConfig)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/CreateUser/__tests__/handler.ts
+++ b/CreateUser/__tests__/handler.ts
@@ -80,8 +80,6 @@ describe("CreateUser", () => {
     const response = await createUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined as any
     );
 
@@ -101,8 +99,6 @@ describe("CreateUser", () => {
 
     const response = await createUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeRequestPayload
     );
@@ -129,8 +125,6 @@ describe("CreateUser", () => {
     const response = await createUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeRequestPayload
     );
 
@@ -153,8 +147,6 @@ describe("CreateUser", () => {
 
     const response = await createUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeRequestPayload
     );
@@ -200,8 +192,6 @@ describe("CreateUser", () => {
 
     const response = await createUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeRequestPayload
     );

--- a/CreateUser/handler.ts
+++ b/CreateUser/handler.ts
@@ -4,7 +4,6 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import * as express from "express";
 import { toError } from "fp-ts/lib/Either";
 import { fromEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -156,7 +155,6 @@ export function CreateUserHandler(
  * Wraps a CreateUser handler inside an Express request handler.
  */
 export function CreateUser(
-  serviceModel: ServiceModel,
   adb2cCreds: IServicePrincipalCreds,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig

--- a/CreateUser/index.ts
+++ b/CreateUser/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { CreateUser } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
@@ -67,7 +44,7 @@ secureExpressApp(app);
 // Add express route
 app.post(
   "/adm/users",
-  CreateUser(serviceModel, adb2cCreds, servicePrincipalCreds, azureApimConfig)
+  CreateUser(adb2cCreds, servicePrincipalCreds, azureApimConfig)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetService/__tests__/handler.test.ts
+++ b/GetService/__tests__/handler.test.ts
@@ -25,8 +25,6 @@ describe("GetServiceHandler", () => {
     const response = await getServiceHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServiceId
     );
 
@@ -51,8 +49,6 @@ describe("GetServiceHandler", () => {
     const response = await getServiceHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServiceId
     );
 
@@ -75,8 +71,6 @@ describe("GetServiceHandler", () => {
       mockServiceModel as any
     );
     const response = await getServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServiceId

--- a/GetServices/__tests__/handler.test.ts
+++ b/GetServices/__tests__/handler.test.ts
@@ -20,8 +20,6 @@ describe("GetServices", () => {
 
     const response = await getServicesHandler(
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any // Not used
     );
 
@@ -60,8 +58,6 @@ describe("GetServices", () => {
     const getServicesHandler = GetServicesHandler(mockServiceModel as any);
 
     const response = await getServicesHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any // Not used
     );

--- a/GetSubscriptionKeys/__tests__/handler.test.ts
+++ b/GetSubscriptionKeys/__tests__/handler.test.ts
@@ -75,8 +75,6 @@ describe("GetSubscriptionKeysHandler", () => {
     const response = await getSubscriptionKeysHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       aNotExistingSubscriptionId
     );
     expect(response.kind).toEqual("IResponseErrorNotFound");
@@ -90,8 +88,6 @@ describe("GetSubscriptionKeysHandler", () => {
     const response = await getSubscriptionKeysHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       aBreakingApimSubscriptionId
     );
     expect(response.kind).toEqual("IResponseErrorInternal");
@@ -104,8 +100,6 @@ describe("GetSubscriptionKeysHandler", () => {
     );
     const response = await getSubscriptionKeysHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       aValidSubscriptionId
     );

--- a/GetSubscriptionKeys/handler.ts
+++ b/GetSubscriptionKeys/handler.ts
@@ -2,7 +2,6 @@ import { Context } from "@azure/functions";
 
 import * as express from "express";
 
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -92,7 +91,6 @@ export function GetSubscriptionKeysHandler(
  * Wraps a GetSubscriptionsKeys handler inside an Express request handler.
  */
 export function GetSubscriptionKeys(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): express.RequestHandler {

--- a/GetSubscriptionKeys/handler.ts
+++ b/GetSubscriptionKeys/handler.ts
@@ -8,23 +8,11 @@ import {
   IAzureApiAuthorization,
   UserGroup
 } from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import {
-  AzureUserAttributesMiddleware,
-  IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import {
-  ClientIp,
-  ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
 } from "io-functions-commons/dist/src/utils/request_middleware";
-import {
-  checkSourceIpForHandler,
-  clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
 
 import { toError } from "fp-ts/lib/Either";
 import { tryCatch } from "fp-ts/lib/TaskEither";
@@ -47,8 +35,6 @@ import { ServiceIdMiddleware } from "../utils/middlewares/serviceid";
 type IGetSubscriptionKeysHandler = (
   context: Context,
   auth: IAzureApiAuthorization,
-  clientIp: ClientIp,
-  userAttributes: IAzureUserAttributes,
   serviceId: ServiceId
 ) => Promise<
   | IResponseSuccessJson<{
@@ -63,7 +49,7 @@ export function GetSubscriptionKeysHandler(
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): IGetSubscriptionKeysHandler {
-  return async (context, _, __, ___, serviceId) => {
+  return async (context, _, serviceId) => {
     const response = await getApiClient(
       servicePrincipalCreds,
       azureApimConfig.subscriptionId
@@ -120,17 +106,9 @@ export function GetSubscriptionKeys(
     ContextMiddleware(),
     // Allow only users in the ApiServiceKeyRead group
     AzureApiAuthMiddleware(new Set([UserGroup.ApiUserAdmin])),
-    // Extracts the client IP from the request
-    ClientIpMiddleware,
-    // Extracts custom user attributes from the request
-    AzureUserAttributesMiddleware(serviceModel),
     // Extracts the ServiceId from the URL path parameter
     ServiceIdMiddleware
   );
 
-  return wrapRequestHandler(
-    middlewaresWrap(
-      checkSourceIpForHandler(handler, (_, __, c, u, ___) => ipTuple(c, u))
-    )
-  );
+  return wrapRequestHandler(middlewaresWrap(handler));
 }

--- a/GetSubscriptionKeys/index.ts
+++ b/GetSubscriptionKeys/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { GetSubscriptionKeys } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -60,7 +37,7 @@ secureExpressApp(app);
 // Add express route
 app.get(
   "/adm/services/:serviceid/keys",
-  GetSubscriptionKeys(serviceModel, servicePrincipalCreds, azureApimConfig)
+  GetSubscriptionKeys(servicePrincipalCreds, azureApimConfig)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetUser/__tests__/handler.test.ts
+++ b/GetUser/__tests__/handler.test.ts
@@ -76,8 +76,6 @@ describe("GetUser", () => {
     const response = await getUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined as any
     );
 
@@ -96,8 +94,6 @@ describe("GetUser", () => {
     const response = await getUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined as any
     );
 
@@ -113,8 +109,6 @@ describe("GetUser", () => {
 
     const response = await getUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined as any
     );
@@ -133,8 +127,6 @@ describe("GetUser", () => {
 
     const response = await getUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined as any
     );
@@ -158,8 +150,6 @@ describe("GetUser", () => {
     const response = await getUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined as any
     );
 
@@ -181,8 +171,6 @@ describe("GetUser", () => {
 
     const response = await getUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined as any
     );
@@ -206,8 +194,6 @@ describe("GetUser", () => {
     const response = await getUserHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined as any
     );
 
@@ -229,8 +215,6 @@ describe("GetUser", () => {
 
     const response = await getUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined as any
     );
@@ -330,8 +314,6 @@ describe("GetUser", () => {
 
     const response = await getUserHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined as any
     );

--- a/GetUser/handler.ts
+++ b/GetUser/handler.ts
@@ -12,7 +12,6 @@ import {
   TaskEither,
   tryCatch
 } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -238,7 +237,6 @@ export function GetUserHandler(
  * Wraps a GetUsers handler inside an Express request handler.
  */
 export function GetUser(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): express.RequestHandler {

--- a/GetUser/index.ts
+++ b/GetUser/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { GetUser } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -58,10 +35,7 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get(
-  "/adm/users/:email",
-  GetUser(serviceModel, servicePrincipalCreds, azureApimConfig)
-);
+app.get("/adm/users/:email", GetUser(servicePrincipalCreds, azureApimConfig));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/GetUsers/__tests__/handler.test.ts
+++ b/GetUsers/__tests__/handler.test.ts
@@ -119,8 +119,6 @@ describe("GetUsers", () => {
     const response = await getUsersHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined
     );
     expect(response.kind).toEqual("IResponseErrorInternal");
@@ -148,8 +146,6 @@ describe("GetUsers", () => {
 
     const response = await getUsersHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       undefined
     );
@@ -217,8 +213,6 @@ describe("GetUsers", () => {
     const responseWithNext: any = await getUsersHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       undefined
     );
 
@@ -235,8 +229,6 @@ describe("GetUsers", () => {
     const lastCursor = mockedApimUsersList.length - resultsPerPage;
     const responseWithoutNext = await getUsersHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       lastCursor
     );

--- a/GetUsers/handler.ts
+++ b/GetUsers/handler.ts
@@ -3,7 +3,6 @@ import * as express from "express";
 import { array } from "fp-ts/lib/Array";
 import { either, toError } from "fp-ts/lib/Either";
 import { tryCatch } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -92,7 +91,6 @@ export function GetUsersHandler(
  * Wraps a GetUsers handler inside an Express request handler.
  */
 export function GetUsers(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig,
   functionsUrl: string

--- a/GetUsers/index.ts
+++ b/GetUsers/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { GetUsers } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -62,7 +39,7 @@ secureExpressApp(app);
 // Add express route
 app.get(
   "/adm/users",
-  GetUsers(serviceModel, servicePrincipalCreds, azureApimConfig, azureApimHost)
+  GetUsers(servicePrincipalCreds, azureApimConfig, azureApimHost)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/RegenerateSubscriptionKeys/__test__/handler.test.ts
+++ b/RegenerateSubscriptionKeys/__test__/handler.test.ts
@@ -100,8 +100,6 @@ describe("RegenerateSubscriptionKeysHandler", () => {
     const response = await regenerateSubscriptionKeysHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       aNotExistingSubscriptionId,
       { key_type: SubscriptionKeyTypeEnum.PRIMARY_KEY }
     );
@@ -115,8 +113,6 @@ describe("RegenerateSubscriptionKeysHandler", () => {
     );
     const response = await regenerateSubscriptionKeysHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       aBreakingApimSubscriptionId,
       { key_type: SubscriptionKeyTypeEnum.PRIMARY_KEY }
@@ -132,8 +128,6 @@ describe("RegenerateSubscriptionKeysHandler", () => {
     // Primary key regeneration
     const firstResponse = await regenerateSubscriptionKeysHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       aValidSubscriptionId,
       { key_type: SubscriptionKeyTypeEnum.PRIMARY_KEY }
@@ -155,8 +149,6 @@ describe("RegenerateSubscriptionKeysHandler", () => {
     // Secondary key regeneration
     const secondResponse = await regenerateSubscriptionKeysHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       aValidSubscriptionId,
       { key_type: SubscriptionKeyTypeEnum.SECONDARY_KEY }

--- a/RegenerateSubscriptionKeys/handler.ts
+++ b/RegenerateSubscriptionKeys/handler.ts
@@ -8,23 +8,11 @@ import {
   IAzureApiAuthorization,
   UserGroup
 } from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import {
-  AzureUserAttributesMiddleware,
-  IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import {
-  ClientIp,
-  ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import {
   withRequestMiddlewares,
   wrapRequestHandler
 } from "io-functions-commons/dist/src/utils/request_middleware";
-import {
-  checkSourceIpForHandler,
-  clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
 
 import { toError } from "fp-ts/lib/Either";
 import { tryCatch } from "fp-ts/lib/TaskEither";
@@ -51,8 +39,6 @@ import { SubscriptionKeyTypeMiddleware } from "../utils/middlewares/subscription
 type IGetSubscriptionKeysHandler = (
   context: Context,
   auth: IAzureApiAuthorization,
-  clientIp: ClientIp,
-  userAttributes: IAzureUserAttributes,
   serviceId: ServiceId,
   keyTypePayload: SubscriptionKeyTypePayload
 ) => Promise<
@@ -65,7 +51,7 @@ export function RegenerateSubscriptionKeysHandler(
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): IGetSubscriptionKeysHandler {
-  return async (context, __, ___, ____, serviceId, keyTypePayload) => {
+  return async (context, _, serviceId, keyTypePayload) => {
     const response = await getApiClient(
       servicePrincipalCreds,
       azureApimConfig.subscriptionId
@@ -142,20 +128,10 @@ export function RegenerateSubscriptionKeys(
     ContextMiddleware(),
     // Allow only users in the ApiServiceKeyWrite group
     AzureApiAuthMiddleware(new Set([UserGroup.ApiUserAdmin])),
-    // Extracts the client IP from the request
-    ClientIpMiddleware,
-    // Extracts custom user attributes from the request
-    AzureUserAttributesMiddleware(serviceModel),
     // Extracts the ServiceId from the URL path parameter
     ServiceIdMiddleware,
     SubscriptionKeyTypeMiddleware
   );
 
-  return wrapRequestHandler(
-    middlewaresWrap(
-      checkSourceIpForHandler(handler, (_, __, c, u, ___, ____) =>
-        ipTuple(c, u)
-      )
-    )
-  );
+  return wrapRequestHandler(middlewaresWrap(handler));
 }

--- a/RegenerateSubscriptionKeys/handler.ts
+++ b/RegenerateSubscriptionKeys/handler.ts
@@ -2,7 +2,6 @@ import { Context } from "@azure/functions";
 
 import * as express from "express";
 
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -114,7 +113,6 @@ export function RegenerateSubscriptionKeysHandler(
  * Wraps a GetSubscriptionsKeys handler inside an Express request handler.
  */
 export function RegenerateSubscriptionKeys(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): express.RequestHandler {

--- a/RegenerateSubscriptionKeys/index.ts
+++ b/RegenerateSubscriptionKeys/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { RegenerateSubscriptionKeys } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -59,11 +36,7 @@ secureExpressApp(app);
 // Add express route
 app.put(
   "/adm/services/:serviceid/keys",
-  RegenerateSubscriptionKeys(
-    serviceModel,
-    servicePrincipalCreds,
-    azureApimConfig
-  )
+  RegenerateSubscriptionKeys(servicePrincipalCreds, azureApimConfig)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/UpdateService/__tests__/handler.test.ts
+++ b/UpdateService/__tests__/handler.test.ts
@@ -51,8 +51,6 @@ describe("UpdateServiceHandler", () => {
     const response = await updateServiceHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServiceId,
       {
         ...aServicePayload,
@@ -79,8 +77,6 @@ describe("UpdateServiceHandler", () => {
     );
 
     const response = await updateServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload.service_id,
@@ -110,8 +106,6 @@ describe("UpdateServiceHandler", () => {
     );
 
     const response = await updateServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload.service_id,
@@ -144,8 +138,6 @@ describe("UpdateServiceHandler", () => {
     );
 
     const response = await updateServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload.service_id,
@@ -181,8 +173,6 @@ describe("UpdateServiceHandler", () => {
     const response = await updateServiceHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServicePayload.service_id,
       {
         ...aServicePayload,
@@ -215,8 +205,6 @@ describe("UpdateServiceHandler", () => {
     );
 
     const response = await updateServiceHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload.service_id,
@@ -262,8 +250,6 @@ describe("UpdateServiceHandler", () => {
 
     await updateServiceHandler(
       contextMock as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       aServicePayload.service_id,
       {

--- a/UpdateUserGroups/__tests__/handler.ts
+++ b/UpdateUserGroups/__tests__/handler.ts
@@ -108,8 +108,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
     );
@@ -129,8 +127,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
     );
@@ -147,8 +143,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
@@ -168,8 +162,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
@@ -192,8 +184,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
@@ -220,8 +210,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.map(_ => _.displayName) }
     );
@@ -246,8 +234,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: ["invalid group"] }
@@ -278,8 +264,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.slice(1, 4).map(_ => _.displayName) }
     );
@@ -309,8 +293,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.slice(1, 4).map(_ => _.displayName) }
     );
@@ -339,8 +321,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: fakeExistingGroups.slice(1, 4).map(_ => _.displayName) }
@@ -376,8 +356,6 @@ describe("UpdateUserGroups", () => {
     const response = await updateUserGroupHandler(
       mockedContext as any,
       undefined as any,
-      undefined as any,
-      undefined as any,
       fakeUserEmail,
       { groups: updatedGroups.map(_ => _.displayName) }
     );
@@ -408,8 +386,6 @@ describe("UpdateUserGroups", () => {
 
     const response = await updateUserGroupHandler(
       mockedContext as any,
-      undefined as any,
-      undefined as any,
       undefined as any,
       fakeUserEmail,
       { groups: updatedGroups.map(_ => _.displayName) }

--- a/UpdateUserGroups/handler.ts
+++ b/UpdateUserGroups/handler.ts
@@ -14,7 +14,6 @@ import {
   taskEitherSeq,
   tryCatch
 } from "fp-ts/lib/TaskEither";
-import { ServiceModel } from "io-functions-commons/dist/src/models/service";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,
@@ -339,7 +338,6 @@ export function UpdateUserGroupHandler(
  * Wraps a GetSubscriptionsKeys handler inside an Express request handler.
  */
 export function UpdateUserGroup(
-  serviceModel: ServiceModel,
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): express.RequestHandler {

--- a/UpdateUserGroups/handler.ts
+++ b/UpdateUserGroups/handler.ts
@@ -20,14 +20,6 @@ import {
   IAzureApiAuthorization,
   UserGroup
 } from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
-import {
-  AzureUserAttributesMiddleware,
-  IAzureUserAttributes
-} from "io-functions-commons/dist/src/utils/middlewares/azure_user_attributes";
-import {
-  ClientIp,
-  ClientIpMiddleware
-} from "io-functions-commons/dist/src/utils/middlewares/client_ip_middleware";
 import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
 import { RequiredParamMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_param";
@@ -35,10 +27,6 @@ import {
   withRequestMiddlewares,
   wrapRequestHandler
 } from "io-functions-commons/dist/src/utils/request_middleware";
-import {
-  checkSourceIpForHandler,
-  clientIPAndCidrTuple as ipTuple
-} from "io-functions-commons/dist/src/utils/source_ip_check";
 import {
   IResponseErrorInternal,
   IResponseErrorNotFound,
@@ -71,8 +59,6 @@ type IGetSubscriptionKeysHandlerResponseError =
 type IGetSubscriptionKeysHandler = (
   context: Context,
   auth: IAzureApiAuthorization,
-  clientIp: ClientIp,
-  userAttributes: IAzureUserAttributes,
   email: EmailAddress,
   userGroupsPayload: UserGroupsPayload
 ) => Promise<
@@ -152,7 +138,7 @@ export function UpdateUserGroupHandler(
   servicePrincipalCreds: IServicePrincipalCreds,
   azureApimConfig: IAzureApimConfig
 ): IGetSubscriptionKeysHandler {
-  return async (context, _, __, ___, email, userGroupsPayload) => {
+  return async (context, _, email, userGroupsPayload) => {
     const internalErrorHandler = (errorMessage: string, error: Error) =>
       genericInternalErrorHandler(
         context,
@@ -367,21 +353,11 @@ export function UpdateUserGroup(
     ContextMiddleware(),
     // Allow only users in the ApiServiceKeyRead group
     AzureApiAuthMiddleware(new Set([UserGroup.ApiUserAdmin])),
-    // Extracts the client IP from the request
-    ClientIpMiddleware,
-    // Extracts custom user attributes from the request
-    AzureUserAttributesMiddleware(serviceModel),
     // Extracts the user email from the URL path
     RequiredParamMiddleware("email", EmailAddress),
     // Extract the user groups payload from the request body
     RequiredBodyPayloadMiddleware(UserGroupsPayload)
   );
 
-  return wrapRequestHandler(
-    middlewaresWrap(
-      checkSourceIpForHandler(handler, (_, __, c, u, ___, ____) =>
-        ipTuple(c, u)
-      )
-    )
-  );
+  return wrapRequestHandler(middlewaresWrap(handler));
 }

--- a/UpdateUserGroups/index.ts
+++ b/UpdateUserGroups/index.ts
@@ -3,13 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { DocumentClient as DocumentDBClient } from "documentdb";
-
-import {
-  SERVICE_COLLECTION_NAME,
-  ServiceModel
-} from "io-functions-commons/dist/src/models/service";
-import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
@@ -18,22 +11,6 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { UpdateUserGroup } from "./handler";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const cosmosDbKey = getRequiredStringEnv("COSMOSDB_KEY");
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
-
-const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
-const servicesCollectionUrl = documentDbUtils.getCollectionUri(
-  documentDbDatabaseUrl,
-  SERVICE_COLLECTION_NAME
-);
-
-const documentClient = new DocumentDBClient(cosmosDbUri, {
-  masterKey: cosmosDbKey
-});
-
-const serviceModel = new ServiceModel(documentClient, servicesCollectionUrl);
 
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
@@ -60,7 +37,7 @@ secureExpressApp(app);
 // Add express route
 app.put(
   "/adm/users/:email/groups",
-  UpdateUserGroup(serviceModel, servicePrincipalCreds, azureApimConfig)
+  UpdateUserGroup(servicePrincipalCreds, azureApimConfig)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/UploadServiceLogo/__test__/handler.test.ts
+++ b/UploadServiceLogo/__test__/handler.test.ts
@@ -24,8 +24,6 @@ describe("UpdateServiceLogoHandler", () => {
     const response = await updateServiceLogoHandler(
       undefined as any, // Not used
       undefined as any, // Not used
-      undefined as any, // Not used
-      undefined as any, // Not used
       aServiceId,
       undefined as any // Not used
     );
@@ -49,8 +47,6 @@ describe("UpdateServiceLogoHandler", () => {
       undefined as any
     );
     const response = await updateServiceLogoHandler(
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       undefined as any, // Not used
       aServiceId,
@@ -87,8 +83,6 @@ describe("UpdateServiceLogoHandler", () => {
     );
     const response = await updateServiceLogoHandler(
       mockedContext as any,
-      undefined as any, // Not used
-      undefined as any, // Not used
       undefined as any, // Not used
       aServiceId,
       requestPayload


### PR DESCRIPTION
This PR aims to remove the usage of the AzurUserAttributesMiddleware. The filter on the client IP will be consequently removed too, together with the ServiceModel parameters not necessary anymore.