### PR TITLE
[#174844930] Restrict subscription(s) output payload properties

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -593,37 +593,9 @@ definitions:
       - $ref: "#/definitions/SubscriptionKeys"
       - type: object
         properties:
-          allow_tracing:
-            type: boolean
-          created_date:
-            type: string
-            format: "date-time"
-          display_name:
-            type: string
-          end_date:
-            type: string
-            format: "date-time"
-          expiration_date:
-            type: string
-            format: "date-time"
           id:
             type: string
-          name:
-            type: string
-          notification_date:
-            type: string
-          owner_id:
-            type: string
           scope:
-            type: string
-          start_date:
-            type: string
-            format: "date-time"
-          state:
-            $ref: "#/definitions/SubscriptionState"
-          state_comment:
-            type: string
-          type:
             type: string
         required:
           - scope

--- a/utils/conversions.ts
+++ b/utils/conversions.ts
@@ -177,24 +177,12 @@ export function subscriptionContractToApiSubscription(
 ): Either<Error, ApiSubscription> {
   return Subscription.decode(
     removeNullProperties({
-      allow_tracing: subscription.allowTracing,
-      created_date: subscription.createdDate,
-      display_name: subscription.displayName,
-      end_date: subscription.endDate,
-      expiration_date: subscription.expirationDate,
       id: subscription.id
         ? subscription.id.substr(subscription.id.lastIndexOf("/") + 1)
         : subscription.id,
-      name: subscription.name,
-      notification_date: subscription.notificationDate,
-      owner_id: subscription.ownerId,
       primary_key: subscription.primaryKey,
       scope: subscription.scope,
-      secondary_key: subscription.secondaryKey,
-      start_date: subscription.startDate,
-      state: subscription.state,
-      state_comment: subscription.stateComment,
-      type: subscription.type
+      secondary_key: subscription.secondaryKey
     })
   ).mapLeft(errorsToError);
 }

--- a/utils/conversions.ts
+++ b/utils/conversions.ts
@@ -182,7 +182,9 @@ export function subscriptionContractToApiSubscription(
       display_name: subscription.displayName,
       end_date: subscription.endDate,
       expiration_date: subscription.expirationDate,
-      id: subscription.id,
+      id: subscription.id
+        ? subscription.id.substr(subscription.id.lastIndexOf("/") + 1)
+        : subscription.id,
       name: subscription.name,
       notification_date: subscription.notificationDate,
       owner_id: subscription.ownerId,


### PR DESCRIPTION
This PR:
- modifies the `Subscription`' s property `id` mapping.
- modifies `Subscription`' s definition in order to remove unnecessary properties
