### PR TITLE
[#174823724] Add token name to GetUser from Azure ADB2C

### DIFF
--- a/CreateUser/handler.ts
+++ b/CreateUser/handler.ts
@@ -1,9 +1,7 @@
 import { Context } from "@azure/functions";
-import { GraphRbacManagementClient } from "@azure/graph";
-import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import * as express from "express";
 import { toError } from "fp-ts/lib/Either";
-import { fromEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { fromEither, tryCatch } from "fp-ts/lib/TaskEither";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,

--- a/CreateUser/handler.ts
+++ b/CreateUser/handler.ts
@@ -24,6 +24,7 @@ import { UserCreated } from "../generated/definitions/UserCreated";
 import { UserPayload } from "../generated/definitions/UserPayload";
 import {
   getApiClient,
+  getGraphRbacManagementClient,
   IAzureApimConfig,
   IServicePrincipalCreds
 } from "../utils/apim";
@@ -35,26 +36,6 @@ type ICreateUserHandler = (
   auth: IAzureApiAuthorization,
   userPayload: UserPayload
 ) => Promise<IResponseSuccessJson<UserCreated> | IResponseErrorInternal>;
-
-function getGraphRbacManagementClient(
-  adb2cCreds: IServicePrincipalCreds
-): TaskEither<Error, GraphRbacManagementClient> {
-  return tryCatch(
-    () =>
-      msRestNodeAuth.loginWithServicePrincipalSecret(
-        adb2cCreds.clientId,
-        adb2cCreds.secret,
-        adb2cCreds.tenantId,
-        { tokenAudience: "graph" }
-      ),
-    toError
-  ).map(
-    credentials =>
-      new GraphRbacManagementClient(credentials, adb2cCreds.tenantId, {
-        baseUri: "https://graph.windows.net"
-      })
-  );
-}
 
 export function CreateUserHandler(
   adb2cCredentials: IServicePrincipalCreds,

--- a/GetUser/index.ts
+++ b/GetUser/index.ts
@@ -12,6 +12,11 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { GetUser } from "./handler";
 
+const adb2cCreds = {
+  clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
+  secret: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
+  tenantId: getRequiredStringEnv("ADB2C_TENANT_ID")
+};
 const servicePrincipalCreds = {
   clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
   secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
@@ -35,7 +40,10 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get("/adm/users/:email", GetUser(servicePrincipalCreds, azureApimConfig));
+app.get(
+  "/adm/users/:email",
+  GetUser(adb2cCreds, servicePrincipalCreds, azureApimConfig)
+);
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -619,6 +619,9 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Subscription"
+      token_name:
+        type: string
+        minLength: 1
   UserIdentityContract:
     type: object
     properties:

--- a/utils/apim.ts
+++ b/utils/apim.ts
@@ -1,5 +1,6 @@
 import { ApiManagementClient } from "@azure/arm-apimanagement";
 import { GroupContract } from "@azure/arm-apimanagement/esm/models";
+import { GraphRbacManagementClient } from "@azure/graph";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { toError } from "fp-ts/lib/Either";
 import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
@@ -29,6 +30,26 @@ export function getApiClient(
       ),
     toError
   ).map(credentials => new ApiManagementClient(credentials, subscriptionId));
+}
+
+export function getGraphRbacManagementClient(
+  adb2cCreds: IServicePrincipalCreds
+): TaskEither<Error, GraphRbacManagementClient> {
+  return tryCatch(
+    () =>
+      msRestNodeAuth.loginWithServicePrincipalSecret(
+        adb2cCreds.clientId,
+        adb2cCreds.secret,
+        adb2cCreds.tenantId,
+        { tokenAudience: "graph" }
+      ),
+    toError
+  ).map(
+    credentials =>
+      new GraphRbacManagementClient(credentials, adb2cCreds.tenantId, {
+        baseUri: "https://graph.windows.net"
+      })
+  );
 }
 
 export function getUserGroups(


### PR DESCRIPTION
This PR is useful to retrieve custom extension property `token_name` from Azure AD B2C, while calling `GetUser` API. Property value is also mapped into `UserInfo` API model in order to make possible info's propagation to io-functions-services.