### PR TITLE
[#175059122] Centralise config read

### DIFF
--- a/CreateDevelopmentProfile/index.ts
+++ b/CreateDevelopmentProfile/index.ts
@@ -24,10 +24,8 @@ secureExpressApp(app);
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-
 const profilesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(PROFILE_COLLECTION_NAME);
 
 const profileModel = new ProfileModel(profilesContainer);

--- a/CreateDevelopmentProfile/index.ts
+++ b/CreateDevelopmentProfile/index.ts
@@ -14,7 +14,7 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
 import { CreateDevelopmentProfile } from "./handler";
 
@@ -22,7 +22,7 @@ import { CreateDevelopmentProfile } from "./handler";
 const app = express();
 secureExpressApp(app);
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 

--- a/CreateDevelopmentProfile/index.ts
+++ b/CreateDevelopmentProfile/index.ts
@@ -8,13 +8,13 @@ import {
   ProfileModel
 } from "io-functions-commons/dist/src/models/profile";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
 import { CreateDevelopmentProfile } from "./handler";
 
@@ -22,7 +22,9 @@ import { CreateDevelopmentProfile } from "./handler";
 const app = express();
 secureExpressApp(app);
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const profilesContainer = cosmosdbClient
   .database(cosmosDbName)

--- a/CreateService/index.ts
+++ b/CreateService/index.ts
@@ -16,10 +16,10 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { CreateService } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 

--- a/CreateService/index.ts
+++ b/CreateService/index.ts
@@ -8,7 +8,6 @@ import {
   ServiceModel
 } from "io-functions-commons/dist/src/models/service";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -17,9 +16,12 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { CreateService } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient
   .database(cosmosDbName)

--- a/CreateService/index.ts
+++ b/CreateService/index.ts
@@ -21,10 +21,8 @@ import { CreateService } from "./handler";
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-
 const servicesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);

--- a/CreateSubscription/index.ts
+++ b/CreateSubscription/index.ts
@@ -3,24 +3,26 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { CreateSubscription } from "./handler";
 
+const config = getConfig();
+
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 // tslint:disable-next-line: no-let

--- a/CreateSubscription/index.ts
+++ b/CreateSubscription/index.ts
@@ -9,10 +9,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { CreateSubscription } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const servicePrincipalCreds = {
   clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,

--- a/CreateUser/index.ts
+++ b/CreateUser/index.ts
@@ -10,10 +10,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { CreateUser } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
   secret: getRequiredStringEnv("ADB2C_CLIENT_KEY"),

--- a/CreateUser/index.ts
+++ b/CreateUser/index.ts
@@ -10,8 +10,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { CreateUser } from "./handler";
 
+const config = getConfig();
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
   secret: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
@@ -19,15 +21,15 @@ const adb2cCreds = {
 };
 
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 // tslint:disable-next-line: no-let

--- a/DeleteUserDataActivity/index.ts
+++ b/DeleteUserDataActivity/index.ts
@@ -16,10 +16,9 @@ import { NotificationStatusDeletableModel } from "../utils/extensions/models/not
 import { ProfileDeletableModel } from "../utils/extensions/models/profile";
 
 const config = getConfigOrThrow();
-const cosmosDbName = config.COSMOSDB_NAME;
 
 const messagesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(MESSAGE_COLLECTION_NAME);
 
 const messageModel = new MessageDeletableModel(
@@ -28,7 +27,7 @@ const messageModel = new MessageDeletableModel(
 );
 
 const messageStatusesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(MESSAGE_STATUS_COLLECTION_NAME);
 
 const messageStatusModel = new MessageStatusDeletableModel(
@@ -36,7 +35,7 @@ const messageStatusModel = new MessageStatusDeletableModel(
 );
 
 const notificationsContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(NOTIFICATION_COLLECTION_NAME);
 
 const notificationModel = new NotificationDeletableModel(
@@ -44,7 +43,7 @@ const notificationModel = new NotificationDeletableModel(
 );
 
 const notificationStatusesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(NOTIFICATION_STATUS_COLLECTION_NAME);
 
 const notificationStatusModel = new NotificationStatusDeletableModel(
@@ -52,7 +51,7 @@ const notificationStatusModel = new NotificationStatusDeletableModel(
 );
 
 const profilesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(PROFILE_COLLECTION_NAME);
 
 const profileModel = new ProfileDeletableModel(profilesContainer);

--- a/DeleteUserDataActivity/index.ts
+++ b/DeleteUserDataActivity/index.ts
@@ -8,14 +8,14 @@ import { MESSAGE_STATUS_COLLECTION_NAME } from "io-functions-commons/dist/src/mo
 import { NOTIFICATION_COLLECTION_NAME } from "io-functions-commons/dist/src/models/notification";
 import { NOTIFICATION_STATUS_COLLECTION_NAME } from "io-functions-commons/dist/src/models/notification_status";
 import { PROFILE_COLLECTION_NAME } from "io-functions-commons/dist/src/models/profile";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { MessageDeletableModel } from "../utils/extensions/models/message";
 import { MessageStatusDeletableModel } from "../utils/extensions/models/message_status";
 import { NotificationDeletableModel } from "../utils/extensions/models/notification";
 import { NotificationStatusDeletableModel } from "../utils/extensions/models/notification_status";
 import { ProfileDeletableModel } from "../utils/extensions/models/profile";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbName = config.COSMOSDB_NAME;
 
 const messagesContainer = cosmosdbClient

--- a/DeleteUserDataActivity/index.ts
+++ b/DeleteUserDataActivity/index.ts
@@ -1,5 +1,3 @@
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { cosmosdbClient } from "../utils/cosmosdb";
 
 import { createDeleteUserDataActivityHandler } from "./handler";
@@ -10,13 +8,15 @@ import { MESSAGE_STATUS_COLLECTION_NAME } from "io-functions-commons/dist/src/mo
 import { NOTIFICATION_COLLECTION_NAME } from "io-functions-commons/dist/src/models/notification";
 import { NOTIFICATION_STATUS_COLLECTION_NAME } from "io-functions-commons/dist/src/models/notification_status";
 import { PROFILE_COLLECTION_NAME } from "io-functions-commons/dist/src/models/profile";
+import { getConfig } from "../utils/config";
 import { MessageDeletableModel } from "../utils/extensions/models/message";
 import { MessageStatusDeletableModel } from "../utils/extensions/models/message_status";
 import { NotificationDeletableModel } from "../utils/extensions/models/notification";
 import { NotificationStatusDeletableModel } from "../utils/extensions/models/notification_status";
 import { ProfileDeletableModel } from "../utils/extensions/models/profile";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const messagesContainer = cosmosdbClient
   .database(cosmosDbName)
@@ -24,7 +24,7 @@ const messagesContainer = cosmosdbClient
 
 const messageModel = new MessageDeletableModel(
   messagesContainer,
-  getRequiredStringEnv("MESSAGE_CONTAINER_NAME")
+  config.MESSAGE_CONTAINER_NAME
 );
 
 const messageStatusesContainer = cosmosdbClient
@@ -58,16 +58,12 @@ const profilesContainer = cosmosdbClient
 const profileModel = new ProfileDeletableModel(profilesContainer);
 
 const userDataBackupBlobService = createBlobService(
-  getRequiredStringEnv("UserDataBackupStorageConnection")
+  config.UserDataBackupStorageConnection
 );
 
-const messageContentBlobService = createBlobService(
-  getRequiredStringEnv("StorageConnection")
-);
+const messageContentBlobService = createBlobService(config.StorageConnection);
 
-const userDataBackupContainerName = getRequiredStringEnv(
-  "USER_DATA_BACKUP_CONTAINER_NAME"
-);
+const userDataBackupContainerName = config.USER_DATA_BACKUP_CONTAINER_NAME;
 
 const activityFunctionHandler = createDeleteUserDataActivityHandler({
   messageContentBlobService,

--- a/ExtractUserDataActivity/index.ts
+++ b/ExtractUserDataActivity/index.ts
@@ -23,9 +23,9 @@ import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
 } from "io-functions-commons/dist/src/models/profile";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 

--- a/ExtractUserDataActivity/index.ts
+++ b/ExtractUserDataActivity/index.ts
@@ -1,5 +1,3 @@
-﻿import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { cosmosdbClient } from "../utils/cosmosdb";
 
 import { createExtractUserDataActivityHandler } from "./handler";
@@ -25,13 +23,15 @@ import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
 } from "io-functions-commons/dist/src/models/profile";
+import { getConfig } from "../utils/config";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 
 const messageModel = new MessageModel(
   database.container(MESSAGE_COLLECTION_NAME),
-  getRequiredStringEnv("MESSAGE_CONTAINER_NAME")
+  config.MESSAGE_CONTAINER_NAME
 );
 
 const messageStatusModel = new MessageStatusModel(
@@ -51,14 +51,12 @@ const profileModel = new ProfileModel(
 );
 
 const userDataBlobService = createBlobService(
-  getRequiredStringEnv("UserDataArchiveStorageConnection")
+  config.UserDataArchiveStorageConnection
 );
 
-const messageContentBlobService = createBlobService(
-  getRequiredStringEnv("StorageConnection")
-);
+const messageContentBlobService = createBlobService(config.StorageConnection);
 
-const userDataContainerName = getRequiredStringEnv("USER_DATA_CONTAINER_NAME");
+const userDataContainerName = config.USER_DATA_CONTAINER_NAME;
 
 const activityFunctionHandler = createExtractUserDataActivityHandler({
   messageContentBlobService,

--- a/ExtractUserDataActivity/index.ts
+++ b/ExtractUserDataActivity/index.ts
@@ -26,8 +26,8 @@ import {
 import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 
 const messageModel = new MessageModel(
   database.container(MESSAGE_COLLECTION_NAME),

--- a/GetProfileActivity/index.ts
+++ b/GetProfileActivity/index.ts
@@ -8,8 +8,8 @@ import { getConfigOrThrow } from "../utils/config";
 import { createGetProfileActivityHandler } from "./handler";
 
 const config = getConfigOrThrow();
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 
 const profileModel = new ProfileModel(
   database.container(PROFILE_COLLECTION_NAME)

--- a/GetProfileActivity/index.ts
+++ b/GetProfileActivity/index.ts
@@ -1,14 +1,14 @@
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { cosmosdbClient } from "../utils/cosmosdb";
 
 import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
 } from "io-functions-commons/dist/src/models/profile";
+import { getConfig } from "../utils/config";
 import { createGetProfileActivityHandler } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 
 const profileModel = new ProfileModel(

--- a/GetProfileActivity/index.ts
+++ b/GetProfileActivity/index.ts
@@ -4,10 +4,10 @@ import {
   PROFILE_COLLECTION_NAME,
   ProfileModel
 } from "io-functions-commons/dist/src/models/profile";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { createGetProfileActivityHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 

--- a/GetService/index.ts
+++ b/GetService/index.ts
@@ -20,10 +20,9 @@ import { getConfigOrThrow } from "../utils/config";
 import { GetService } from "./handler";
 
 const config = getConfigOrThrow();
-const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);

--- a/GetService/index.ts
+++ b/GetService/index.ts
@@ -16,10 +16,10 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { GetService } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient

--- a/GetService/index.ts
+++ b/GetService/index.ts
@@ -8,7 +8,6 @@ import {
   ServiceModel
 } from "io-functions-commons/dist/src/models/service";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -17,9 +16,11 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { GetService } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient
   .database(cosmosDbName)

--- a/GetServices/index.ts
+++ b/GetServices/index.ts
@@ -21,10 +21,8 @@ import { GetServices } from "./handler";
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-
 const servicesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);

--- a/GetServices/index.ts
+++ b/GetServices/index.ts
@@ -16,10 +16,10 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { GetServices } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 

--- a/GetServices/index.ts
+++ b/GetServices/index.ts
@@ -8,7 +8,6 @@ import {
   ServiceModel
 } from "io-functions-commons/dist/src/models/service";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -17,9 +16,12 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { GetServices } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient
   .database(cosmosDbName)

--- a/GetSubscriptionKeys/index.ts
+++ b/GetSubscriptionKeys/index.ts
@@ -9,10 +9,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { GetSubscriptionKeys } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const servicePrincipalCreds = {
   clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,

--- a/GetSubscriptionKeys/index.ts
+++ b/GetSubscriptionKeys/index.ts
@@ -3,24 +3,26 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { GetSubscriptionKeys } from "./handler";
 
+const config = getConfig();
+
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 // tslint:disable-next-line: no-let

--- a/GetUser/index.ts
+++ b/GetUser/index.ts
@@ -10,10 +10,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { GetUser } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),

--- a/GetUser/index.ts
+++ b/GetUser/index.ts
@@ -10,7 +10,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { GetUser } from "./handler";
+
+const config = getConfig();
 
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
@@ -18,14 +21,14 @@ const adb2cCreds = {
   tenantId: getRequiredStringEnv("ADB2C_TENANT_ID")
 };
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 const adb2cTokenAttributeName = getRequiredStringEnv(

--- a/GetUserDataProcessingActivity/index.ts
+++ b/GetUserDataProcessingActivity/index.ts
@@ -9,8 +9,8 @@ import { getConfigOrThrow } from "../utils/config";
 import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
 const config = getConfigOrThrow();
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 
 const userDataProcessingModel = new UserDataProcessingModel(
   database.container(USER_DATA_PROCESSING_COLLECTION_NAME)

--- a/GetUserDataProcessingActivity/index.ts
+++ b/GetUserDataProcessingActivity/index.ts
@@ -3,13 +3,13 @@ import {
   UserDataProcessingModel
 } from "io-functions-commons/dist/src/models/user_data_processing";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 
 const userDataProcessingModel = new UserDataProcessingModel(

--- a/GetUserDataProcessingActivity/index.ts
+++ b/GetUserDataProcessingActivity/index.ts
@@ -5,10 +5,10 @@ import {
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 

--- a/GetUsers/index.ts
+++ b/GetUsers/index.ts
@@ -11,9 +11,9 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { GetUsers } from "./handler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const servicePrincipalCreds = {
   clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,

--- a/GetUsers/index.ts
+++ b/GetUsers/index.ts
@@ -3,7 +3,6 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -12,18 +11,22 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { GetUsers } from "./handler";
 
+import { getConfig } from "../utils/config";
+
+const config = getConfig();
+
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
-const azureApimHost = getRequiredStringEnv("AZURE_APIM_HOST");
+const azureApimHost = config.AZURE_APIM_HOST;
 
 // tslint:disable-next-line: no-let
 let logger: Context["log"] | undefined;

--- a/RegenerateSubscriptionKeys/index.ts
+++ b/RegenerateSubscriptionKeys/index.ts
@@ -9,10 +9,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { RegenerateSubscriptionKeys } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const servicePrincipalCreds = {
   clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,

--- a/RegenerateSubscriptionKeys/index.ts
+++ b/RegenerateSubscriptionKeys/index.ts
@@ -3,24 +3,26 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { RegenerateSubscriptionKeys } from "./handler";
 
+const config = getConfig();
+
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 // tslint:disable-next-line: no-let
 let logger: Context["log"] | undefined;

--- a/SendUserDataDeleteEmailActivity/index.ts
+++ b/SendUserDataDeleteEmailActivity/index.ts
@@ -3,14 +3,14 @@ import { MailMultiTransportConnectionsFromString } from "io-functions-commons/di
 import { MultiTransport } from "io-functions-commons/dist/src/utils/nodemailer";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as NodeMailer from "nodemailer";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import {
   getMailerTransporter,
   getTransportsForConnections
 } from "../utils/email";
 import { getActivityFunction } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 // Optional SendGrid key
 const sendgridApiKey = NonEmptyString.decode(config.SENDGRID_API_KEY).getOrElse(

--- a/SendUserDataDeleteEmailActivity/index.ts
+++ b/SendUserDataDeleteEmailActivity/index.ts
@@ -1,7 +1,5 @@
 import * as HtmlToText from "html-to-text";
-import { MailMultiTransportConnectionsFromString } from "io-functions-commons/dist/src/utils/multi_transport_connection";
 import { MultiTransport } from "io-functions-commons/dist/src/utils/nodemailer";
-import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as NodeMailer from "nodemailer";
 import { getConfigOrThrow } from "../utils/config";
 import {
@@ -11,11 +9,6 @@ import {
 import { getActivityFunction } from "./handler";
 
 const config = getConfigOrThrow();
-
-// Optional SendGrid key
-const sendgridApiKey = NonEmptyString.decode(config.SENDGRID_API_KEY).getOrElse(
-  undefined
-);
 
 // default sender for email
 const MAIL_FROM = config.MAIL_FROM;
@@ -38,7 +31,7 @@ const mailerTransporter =
         isProduction: config.isProduction,
         ...(typeof config.SENDGRID_API_KEY !== "undefined"
           ? {
-              sendgridApiKey: config.SENDGRID_API_KEY,  
+              sendgridApiKey: config.SENDGRID_API_KEY
             }
           : {
               mailupSecret: config.MAILUP_SECRET,

--- a/SendUserDataDownloadMessageActivity/index.ts
+++ b/SendUserDataDownloadMessageActivity/index.ts
@@ -1,11 +1,13 @@
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import { getConfig } from "../utils/config";
 import { timeoutFetch } from "../utils/fetch";
 import { getActivityFunction } from "./handler";
 
+const config = getConfig();
+
 // Needed to call notifications API
-const publicApiUrl = getRequiredStringEnv("PUBLIC_API_URL");
-const publicApiKey = getRequiredStringEnv("PUBLIC_API_KEY");
-const publicDownloadBaseUrl = getRequiredStringEnv("PUBLIC_DOWNLOAD_BASE_URL");
+const publicApiUrl = config.PUBLIC_API_URL;
+const publicApiKey = config.PUBLIC_API_KEY;
+const publicDownloadBaseUrl = config.PUBLIC_DOWNLOAD_BASE_URL;
 
 const index = getActivityFunction(
   publicApiUrl,

--- a/SendUserDataDownloadMessageActivity/index.ts
+++ b/SendUserDataDownloadMessageActivity/index.ts
@@ -1,8 +1,8 @@
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { timeoutFetch } from "../utils/fetch";
 import { getActivityFunction } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 // Needed to call notifications API
 const publicApiUrl = config.PUBLIC_API_URL;

--- a/SetUserDataProcessingStatusActivity/index.ts
+++ b/SetUserDataProcessingStatusActivity/index.ts
@@ -5,10 +5,10 @@ import {
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);

--- a/SetUserDataProcessingStatusActivity/index.ts
+++ b/SetUserDataProcessingStatusActivity/index.ts
@@ -10,8 +10,7 @@ import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 
 const userDataProcessingModel = new UserDataProcessingModel(
   database.container(USER_DATA_PROCESSING_COLLECTION_NAME)

--- a/SetUserDataProcessingStatusActivity/index.ts
+++ b/SetUserDataProcessingStatusActivity/index.ts
@@ -1,15 +1,16 @@
-﻿import {
+import {
   USER_DATA_PROCESSING_COLLECTION_NAME,
   UserDataProcessingModel
 } from "io-functions-commons/dist/src/models/user_data_processing";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { createSetUserDataProcessingStatusActivityHandler } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 
 const userDataProcessingModel = new UserDataProcessingModel(

--- a/SetUserSessionLockActivity/index.ts
+++ b/SetUserSessionLockActivity/index.ts
@@ -1,4 +1,4 @@
-﻿import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import { getConfig } from "../utils/config";
 import { timeoutFetch } from "../utils/fetch";
 import {
   ApiOperation,
@@ -8,8 +8,10 @@ import {
 } from "../utils/sessionApiClient";
 import { createSetUserSessionLockActivityHandler } from "./handler";
 
-const sessionApiUrl = getRequiredStringEnv("SESSION_API_URL");
-const sessionApiKey = getRequiredStringEnv("SESSION_API_KEY");
+const config = getConfig();
+
+const sessionApiUrl = config.SESSION_API_URL;
+const sessionApiKey = config.SESSION_API_KEY;
 
 const withDefaultApiKey: WithDefaultsT<"token"> = (
   apiOperation: ApiOperation

--- a/SetUserSessionLockActivity/index.ts
+++ b/SetUserSessionLockActivity/index.ts
@@ -1,4 +1,4 @@
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { timeoutFetch } from "../utils/fetch";
 import {
   ApiOperation,
@@ -8,7 +8,7 @@ import {
 } from "../utils/sessionApiClient";
 import { createSetUserSessionLockActivityHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const sessionApiUrl = config.SESSION_API_URL;
 const sessionApiKey = config.SESSION_API_KEY;

--- a/UpdateService/index.ts
+++ b/UpdateService/index.ts
@@ -7,8 +7,6 @@ import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
 } from "io-functions-commons/dist/src/models/service";
-
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -17,9 +15,12 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
+import { getConfig } from "../utils/config";
 import { UpdateService } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 
 const servicesContainer = cosmosdbClient
   .database(cosmosDbName)

--- a/UpdateService/index.ts
+++ b/UpdateService/index.ts
@@ -20,10 +20,8 @@ import { UpdateService } from "./handler";
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-
 const servicesContainer = cosmosdbClient
-  .database(cosmosDbName)
+  .database(config.COSMOSDB_NAME)
   .container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);

--- a/UpdateService/index.ts
+++ b/UpdateService/index.ts
@@ -15,10 +15,10 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { UpdateService } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 

--- a/UpdateSubscriptionsFeedActivity/index.ts
+++ b/UpdateSubscriptionsFeedActivity/index.ts
@@ -6,11 +6,11 @@ import { createTableService, TableUtilities } from "azure-storage";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
 import { isNone } from "fp-ts/lib/Option";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { deleteTableEntity, insertTableEntity } from "../utils/storage";
 import { ActivityInput, ActivityResult } from "./types";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const storageConnectionString = config.SubscriptionFeedStorageConnection;
 const tableService = createTableService(storageConnectionString);

--- a/UpdateSubscriptionsFeedActivity/index.ts
+++ b/UpdateSubscriptionsFeedActivity/index.ts
@@ -1,22 +1,21 @@
-﻿import * as crypto from "crypto";
+import * as crypto from "crypto";
 
 import { AzureFunction, Context } from "@azure/functions";
 import { createTableService, TableUtilities } from "azure-storage";
 
 import { readableReport } from "italia-ts-commons/lib/reporters";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
 import { isNone } from "fp-ts/lib/Option";
+import { getConfig } from "../utils/config";
 import { deleteTableEntity, insertTableEntity } from "../utils/storage";
 import { ActivityInput, ActivityResult } from "./types";
 
-const storageConnectionString = getRequiredStringEnv(
-  "SubscriptionFeedStorageConnection"
-);
+const config = getConfig();
+
+const storageConnectionString = config.SubscriptionFeedStorageConnection;
 const tableService = createTableService(storageConnectionString);
 
-const subscriptionsFeedTable = getRequiredStringEnv("SUBSCRIPTIONS_FEED_TABLE");
+const subscriptionsFeedTable = config.SUBSCRIPTIONS_FEED_TABLE;
 
 const insertEntity = insertTableEntity(tableService, subscriptionsFeedTable);
 const deleteEntity = deleteTableEntity(tableService, subscriptionsFeedTable);

--- a/UpdateUserGroups/index.ts
+++ b/UpdateUserGroups/index.ts
@@ -3,24 +3,26 @@ import { Context } from "@azure/functions";
 import * as express from "express";
 import * as winston from "winston";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfig } from "../utils/config";
 import { UpdateUserGroup } from "./handler";
 
+const config = getConfig();
+
 const servicePrincipalCreds = {
-  clientId: getRequiredStringEnv("SERVICE_PRINCIPAL_CLIENT_ID"),
-  secret: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-  tenantId: getRequiredStringEnv("SERVICE_PRINCIPAL_TENANT_ID")
+  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
+  secret: config.SERVICE_PRINCIPAL_SECRET,
+  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
 };
 const azureApimConfig = {
-  apim: getRequiredStringEnv("AZURE_APIM"),
-  apimResourceGroup: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
-  subscriptionId: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID")
+  apim: config.AZURE_APIM,
+  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
+  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 // tslint:disable-next-line: no-let

--- a/UpdateUserGroups/index.ts
+++ b/UpdateUserGroups/index.ts
@@ -9,10 +9,10 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { UpdateUserGroup } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const servicePrincipalCreds = {
   clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,

--- a/UpdateVisibleServicesActivity/index.ts
+++ b/UpdateVisibleServicesActivity/index.ts
@@ -1,10 +1,9 @@
 ﻿import { createBlobService } from "azure-storage";
-
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
+import { getConfig } from "../utils/config";
 import { getUpdateVisibleServicesActivityHandler } from "./handler";
 
-const storageConnectionString = getRequiredStringEnv("StorageConnection");
+const config = getConfig();
+const storageConnectionString = config.StorageConnection;
 const blobService = createBlobService(storageConnectionString);
 
 const activityFunctionHandler = getUpdateVisibleServicesActivityHandler(

--- a/UpdateVisibleServicesActivity/index.ts
+++ b/UpdateVisibleServicesActivity/index.ts
@@ -1,8 +1,8 @@
 ﻿import { createBlobService } from "azure-storage";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { getUpdateVisibleServicesActivityHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const storageConnectionString = config.StorageConnection;
 const blobService = createBlobService(storageConnectionString);
 

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -15,10 +15,10 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { UploadServiceLogo } from "./handler";
 
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -20,8 +20,7 @@ import { cosmosdbClient } from "../utils/cosmosdb";
 
 const config = getConfigOrThrow();
 
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 const logosUrl = config.LOGOS_URL;
 
 const servicesContainer = database.container(SERVICE_COLLECTION_NAME);

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -7,19 +7,22 @@ import {
   SERVICE_COLLECTION_NAME,
   ServiceModel
 } from "io-functions-commons/dist/src/models/service";
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { cosmosdbClient } from "../utils/cosmosdb";
 import { UploadServiceLogo } from "./handler";
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+import { getConfig } from "../utils/config";
+import { cosmosdbClient } from "../utils/cosmosdb";
+
+const config = getConfig();
+
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
-const logosUrl = getRequiredStringEnv("LOGOS_URL");
+const logosUrl = config.LOGOS_URL;
 
 const servicesContainer = database.container(SERVICE_COLLECTION_NAME);
 

--- a/UserDataDeleteOrchestrator/index.ts
+++ b/UserDataDeleteOrchestrator/index.ts
@@ -1,9 +1,9 @@
 import * as df from "durable-functions";
 import { Day } from "italia-ts-commons/lib/units";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { createUserDataDeleteOrchestratorHandler } from "./handler";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const waitInterval = (config.USER_DATA_DELETE_DELAY_DAYS as unknown) as Day;
 

--- a/UserDataDeleteOrchestrator/index.ts
+++ b/UserDataDeleteOrchestrator/index.ts
@@ -1,11 +1,11 @@
 import * as df from "durable-functions";
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { Day } from "italia-ts-commons/lib/units";
+import { getConfig } from "../utils/config";
 import { createUserDataDeleteOrchestratorHandler } from "./handler";
 
-const waitInterval = (getRequiredStringEnv(
-  "USER_DATA_DELETE_DELAY_DAYS"
-) as unknown) as Day;
+const config = getConfig();
+
+const waitInterval = (config.USER_DATA_DELETE_DELAY_DAYS as unknown) as Day;
 
 const orchestrator = df.orchestrator(
   createUserDataDeleteOrchestratorHandler(waitInterval)

--- a/UserDataDownloadOrchestrator/cli.ts
+++ b/UserDataDownloadOrchestrator/cli.ts
@@ -26,10 +26,10 @@ import {
 import { isLeft } from "fp-ts/lib/Either";
 import { isNone } from "fp-ts/lib/Option";
 import { UserDataProcessingChoiceEnum } from "io-functions-commons/dist/generated/definitions/UserDataProcessingChoice";
-import { getConfig } from "../utils/config";
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 
 const context = ({
   log: {

--- a/UserDataDownloadOrchestrator/cli.ts
+++ b/UserDataDownloadOrchestrator/cli.ts
@@ -26,8 +26,10 @@ import {
 import { isLeft } from "fp-ts/lib/Either";
 import { isNone } from "fp-ts/lib/Option";
 import { UserDataProcessingChoiceEnum } from "io-functions-commons/dist/generated/definitions/UserDataProcessingChoice";
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import { getConfig } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
+
+const config = getConfig();
 
 const context = ({
   log: {
@@ -38,7 +40,7 @@ const context = ({
   // tslint:disable-next-line: no-any
 } as any) as Context;
 
-const cosmosDbName = getRequiredStringEnv("COSMOSDB_NAME");
+const cosmosDbName = config.COSMOSDB_NAME;
 const database = cosmosdbClient.database(cosmosDbName);
 
 const userDataProcessingModel = new UserDataProcessingModel(

--- a/UserDataDownloadOrchestrator/cli.ts
+++ b/UserDataDownloadOrchestrator/cli.ts
@@ -40,8 +40,7 @@ const context = ({
   // tslint:disable-next-line: no-any
 } as any) as Context;
 
-const cosmosDbName = config.COSMOSDB_NAME;
-const database = cosmosdbClient.database(cosmosDbName);
+const database = cosmosdbClient.database(config.COSMOSDB_NAME);
 
 const userDataProcessingModel = new UserDataProcessingModel(
   database.container(USER_DATA_PROCESSING_COLLECTION_NAME)

--- a/utils/__tests__/config.test.ts
+++ b/utils/__tests__/config.test.ts
@@ -1,0 +1,178 @@
+import { Either, Right } from "fp-ts/lib/Either";
+import { MailerConfig } from "../config";
+
+const aMailFrom = "example@test.com";
+
+const noop = () => {};
+const expectRight = <L, R>(e: Either<L, R>, t: (r: R) => void = noop) =>
+  e.fold(
+    _ =>
+      fail(`Expecting right, received left. Value: ${JSON.stringify(e.value)}`),
+    _ => t(_)
+  );
+
+const expectLeft = <L, R>(e: Either<L, R>, t: (l: L) => void = noop) =>
+  e.fold(
+    _ => t(_),
+    _ =>
+      fail(`Expecting left, received right. Value: ${JSON.stringify(e.value)}`)
+  );
+
+describe("MailerConfig", () => {
+  it("should decode configuration for sendgrid", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      SENDGRID_API_KEY: "a-sg-key"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectRight(result, value => {
+      expect(value.SENDGRID_API_KEY).toBe("a-sg-key");
+      expect(typeof value.MAILUP_USERNAME).toBe("undefined");
+    });
+  });
+
+  it("should decode configuration for sendgrid", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      SENDGRID_API_KEY: "a-sg-key"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectRight(result, value => {
+      expect(value.SENDGRID_API_KEY).toBe("a-sg-key");
+      expect(typeof value.MAILUP_USERNAME).toBe("undefined");
+    });
+  });
+
+  it("should decode configuration for mailup", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      MAILUP_USERNAME: "a-mu-username",
+      MAILUP_SECRET: "a-mu-secret"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectRight(result, value => {
+      expect(value.MAILUP_USERNAME).toBe("a-mu-username");
+      expect(value.MAILUP_SECRET).toBe("a-mu-secret");
+    });
+  });
+
+  it("should decode configuration with multi transport", () => {
+    const aTransport = {
+      password: "abc".repeat(5),
+      transport: "transport-name",
+      username: "t-username"
+    };
+    const aRawTrasport = [
+      aTransport.transport,
+      aTransport.username,
+      aTransport.password
+    ].join(":");
+
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      MAIL_TRANSPORTS: [aRawTrasport, aRawTrasport].join(";")
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectRight(result, value => {
+      expect(value.MAIL_TRANSPORTS).toEqual([aTransport, aTransport]);
+    });
+  });
+
+  it("should decode configuration for mailhog", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "dev",
+      MAILHOG_HOSTNAME: "a-mh-host"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectRight(result, value => {
+      expect(value.MAILHOG_HOSTNAME).toBe("a-mh-host");
+    });
+  });
+
+  it("should require mailhog if not in prod", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "dev"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectLeft(result);
+  });
+
+  it("should require at least on transporter if in prod", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectLeft(result);
+  });
+
+  it("should not allow mailhog if in prod", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      MAILHOG_HOSTNAME: "a-mh-host"
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectLeft(result);
+  });
+
+  it("should not decode configuration with empty transport", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production",
+      MAIL_TRANSPORTS: ""
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectLeft(result);
+  });
+
+  it("should not decode configuration when no transporter is specified", () => {
+    const rawConf = {
+      MAIL_FROM: aMailFrom
+    };
+    const result = MailerConfig.decode(rawConf);
+
+    expectLeft(result);
+  });
+
+  it("should not decode ambiguos configuration", () => {
+    const withMailUp = {
+      MAILUP_USERNAME: "a-mu-username",
+      MAILUP_SECRET: "a-mu-secret"
+    };
+    const withSendGrid = {
+      SENDGRID_API_KEY: "a-sg-key"
+    };
+    const withMultiTransport = {
+      MAIL_TRANSPORTS: "a-trasnport-name"
+    };
+    const base = {
+      MAIL_FROM: aMailFrom,
+      NODE_ENV: "production"
+    };
+
+    const examples = [
+      { ...base, ...withMailUp, ...withSendGrid },
+      { ...base, ...withMultiTransport, ...withSendGrid },
+      { ...base, ...withMailUp, ...withMultiTransport },
+      { ...base, ...withMailUp, ...withSendGrid, ...withMultiTransport }
+    ];
+
+    examples.map(MailerConfig.decode).forEach(_ => expectLeft(_));
+  });
+});

--- a/utils/__tests__/config.test.ts
+++ b/utils/__tests__/config.test.ts
@@ -61,9 +61,6 @@ describe("MailerConfig", () => {
     expectRight(result, value => {
       expect(value.MAILUP_USERNAME).toBe("a-mu-username");
       expect(value.MAILUP_SECRET).toBe("a-mu-secret");
-      // check types
-      const _: NonEmptyString = value.MAILUP_SECRET;
-      const __: NonEmptyString = value.MAILUP_USERNAME;
     });
   });
 

--- a/utils/__tests__/config.test.ts
+++ b/utils/__tests__/config.test.ts
@@ -34,20 +34,6 @@ describe("MailerConfig", () => {
     });
   });
 
-  it("should decode configuration for sendgrid", () => {
-    const rawConf = {
-      MAIL_FROM: aMailFrom,
-      NODE_ENV: "production",
-      SENDGRID_API_KEY: "a-sg-key"
-    };
-    const result = MailerConfig.decode(rawConf);
-
-    expectRight(result, value => {
-      expect(value.SENDGRID_API_KEY).toBe("a-sg-key");
-      expect(typeof value.MAILUP_USERNAME).toBe("undefined");
-    });
-  });
-
   it("should decode configuration for sendgrid even if mailup conf is passed", () => {
     const rawConf = {
       MAIL_FROM: aMailFrom,

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -38,21 +38,21 @@ export const MailerConfig = t.intersection([
   t.union([
     // Using sendgrid
     t.interface({
-      NODE_ENV: t.literal("production"),
-      MAIL_TRANSPORTS: t.undefined,
-      SENDGRID_API_KEY: NonEmptyString,
-      MAILUP_USERNAME: t.undefined,
+      MAILHOG_HOSTNAME: t.undefined,
       MAILUP_SECRET: t.undefined,
-      MAILHOG_HOSTNAME: t.undefined
+      MAILUP_USERNAME: t.undefined,
+      MAIL_TRANSPORTS: t.undefined,
+      NODE_ENV: t.literal("production"),
+      SENDGRID_API_KEY: NonEmptyString
     }),
     // using mailup
     t.interface({
-      NODE_ENV: t.literal("production"),
-      MAIL_TRANSPORTS: t.undefined,
-      SENDGRID_API_KEY: t.undefined,
-      MAILUP_USERNAME: NonEmptyString,
+      MAILHOG_HOSTNAME: t.undefined,
       MAILUP_SECRET: NonEmptyString,
-      MAILHOG_HOSTNAME: t.undefined
+      MAILUP_USERNAME: NonEmptyString,
+      MAIL_TRANSPORTS: t.undefined,
+      NODE_ENV: t.literal("production"),
+      SENDGRID_API_KEY: t.undefined
     }),
     // Using multi-transport definition
     // Optional multi provider connection string
@@ -60,21 +60,21 @@ export const MailerConfig = t.intersection([
     //   [mailup:username:password;][sendgrid:apikey:;]
     // Note that multiple instances of the same provider can be provided.
     t.interface({
-      NODE_ENV: t.literal("production"),
-      MAIL_TRANSPORTS: MailMultiTransportConnectionsFromString,
-      SENDGRID_API_KEY: t.undefined,
-      MAILUP_USERNAME: t.undefined,
+      MAILHOG_HOSTNAME: t.undefined,
       MAILUP_SECRET: t.undefined,
-      MAILHOG_HOSTNAME: t.undefined
+      MAILUP_USERNAME: t.undefined,
+      MAIL_TRANSPORTS: MailMultiTransportConnectionsFromString,
+      NODE_ENV: t.literal("production"),
+      SENDGRID_API_KEY: t.undefined
     }),
     t.interface({
       // the following states that a mailhog configuration is optional and can be provided only if not in prod
-      NODE_ENV: AnyBut("production", NullableString),
       MAILHOG_HOSTNAME: NonEmptyString,
-      MAIL_TRANSPORTS: t.undefined,
-      SENDGRID_API_KEY: t.undefined,
+      MAILUP_SECRET: t.undefined,
       MAILUP_USERNAME: t.undefined,
-      MAILUP_SECRET: t.undefined
+      MAIL_TRANSPORTS: t.undefined,
+      NODE_ENV: AnyBut("production", NullableString),
+      SENDGRID_API_KEY: t.undefined
     })
   ])
 ]);

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,4 +1,3 @@
-import { MailMultiTransportConnectionsFromString } from "io-functions-commons/dist/src/utils/multi_transport_connection";
 /**
  * Config module
  *
@@ -6,15 +5,18 @@ import { MailMultiTransportConnectionsFromString } from "io-functions-commons/di
  * The configuration is evaluate eagerly at the first access to the module. The module exposes convenient methods to access such value.
  */
 
+import { MailMultiTransportConnectionsFromString } from "io-functions-commons/dist/src/utils/multi_transport_connection";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
-export type NullableString = t.TypeOf<typeof NullableString>;
-const NullableString = t.union([t.string, t.undefined]);
-
-// explude a specific value from a type
-const AnyBut = <A, O = A>(but: A, base: t.Type<A, O> = t.any) =>
+// exclude a specific value from a type
+// as strict equality is performed, allowed input types are constrained to be values not references (object, arrays, etc)
+// tslint:disable-next-line max-union-size
+const AnyBut = <A extends string | number | boolean | symbol, O = A>(
+  but: A,
+  base: t.Type<A, O> = t.any
+) =>
   t.brand(
     base,
     (
@@ -29,22 +31,28 @@ const AnyBut = <A, O = A>(but: A, base: t.Type<A, O> = t.any) =>
 // configuration to send email
 export type MailerConfig = t.TypeOf<typeof MailerConfig>;
 export const MailerConfig = t.intersection([
-  // common fields
+  // common required fields
   t.interface({
     MAIL_FROM: NonEmptyString
   }),
-  // the following union includes the possible configuration variants for different mail transport we use in prod
+  // the following union includes the possible configuration variants for different mail transports we use in prod
   // undefined values are kept for easy usage
   t.union([
     // Using sendgrid
-    t.interface({
-      MAILHOG_HOSTNAME: t.undefined,
-      MAILUP_SECRET: t.undefined,
-      MAILUP_USERNAME: t.undefined,
-      MAIL_TRANSPORTS: t.undefined,
-      NODE_ENV: t.literal("production"),
-      SENDGRID_API_KEY: NonEmptyString
-    }),
+    // we allow mailup values as well, as sendgrid would be selected first if present
+    // see here for the rationale: https://github.com/pagopa/io-functions-admin/pull/89#commitcomment-42917672
+    t.intersection([
+      t.interface({
+        MAILHOG_HOSTNAME: t.undefined,
+        MAIL_TRANSPORTS: t.undefined,
+        NODE_ENV: t.literal("production"),
+        SENDGRID_API_KEY: NonEmptyString
+      }),
+      t.partial({
+        MAILUP_SECRET: NonEmptyString,
+        MAILUP_USERNAME: NonEmptyString
+      })
+    ]),
     // using mailup
     t.interface({
       MAILHOG_HOSTNAME: t.undefined,
@@ -67,13 +75,13 @@ export const MailerConfig = t.intersection([
       NODE_ENV: t.literal("production"),
       SENDGRID_API_KEY: t.undefined
     }),
+    // the following states that a mailhog configuration is optional and can be provided only if not in prod
     t.interface({
-      // the following states that a mailhog configuration is optional and can be provided only if not in prod
       MAILHOG_HOSTNAME: NonEmptyString,
       MAILUP_SECRET: t.undefined,
       MAILUP_USERNAME: t.undefined,
       MAIL_TRANSPORTS: t.undefined,
-      NODE_ENV: AnyBut("production", NullableString),
+      NODE_ENV: AnyBut("production", t.string),
       SENDGRID_API_KEY: t.undefined
     })
   ])

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,8 +1,13 @@
+/**
+ * Config module
+ *
+ * Single point of access for the application confguration. Handles validation on required environment variables.
+ * The configuration is evaluate eagerly at the first access to the module. The module exposes convenient methods to access such value.
+ */
+
 import { tryCatch2v } from "fp-ts/lib/Either";
 import { toError } from "fp-ts/lib/Either";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
-export type IConfig = ReturnType<typeof getEnv>;
 
 // base read function
 // tslint:disable typedef
@@ -76,6 +81,8 @@ const getEnv = () => ({
 
 // No need to re-evaluate this object for each call
 const errorOrConfig = tryCatch2v(getEnv, toError);
+
+export type IConfig = ReturnType<typeof getEnv>;
 
 // tslint:disable typedef
 export function getConfig() {

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -62,7 +62,6 @@ const getEnv = () => ({
   ),
 
   // FIXME: email configuration values may be required or not depending on their values
-  // We
   MAIL_FROM: getRequiredStringEnv("MAIL_FROM"),
   MAIL_TRANSPORTS: process.env.MAIL_TRANSPORTS,
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,0 +1,77 @@
+import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+
+export type IConfig = ReturnType<typeof getConfig>;
+
+// tslint:disable typedef
+export function getConfig() {
+  return {
+    COSMOSDB_KEY: getRequiredStringEnv("COSMOSDB_KEY"),
+    COSMOSDB_NAME: getRequiredStringEnv("COSMOSDB_NAME"),
+    COSMOSDB_URI: getRequiredStringEnv("COSMOSDB_URI"),
+
+    SERVICE_PRINCIPAL_CLIENT_ID: getRequiredStringEnv(
+      "SERVICE_PRINCIPAL_CLIENT_ID"
+    ),
+    SERVICE_PRINCIPAL_SECRET: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
+    SERVICE_PRINCIPAL_TENANT_ID: getRequiredStringEnv(
+      "SERVICE_PRINCIPAL_TENANT_ID"
+    ),
+
+    AZURE_APIM: getRequiredStringEnv("AZURE_APIM"),
+    AZURE_APIM_HOST: getRequiredStringEnv("AZURE_APIM_HOST"),
+    AZURE_APIM_RESOURCE_GROUP: getRequiredStringEnv(
+      "AZURE_APIM_RESOURCE_GROUP"
+    ),
+    AZURE_SUBSCRIPTION_ID: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID"),
+
+    ADB2C_CLIENT_ID: getRequiredStringEnv("ADB2C_CLIENT_ID"),
+    ADB2C_CLIENT_KEY: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
+    ADB2C_TENANT_ID: getRequiredStringEnv("ADB2C_TENANT_ID"),
+
+    UserDataBackupStorageConnection: getRequiredStringEnv(
+      "UserDataBackupStorageConnection"
+    ),
+
+    MESSAGE_CONTAINER_NAME: getRequiredStringEnv("MESSAGE_CONTAINER_NAME"),
+    USER_DATA_BACKUP_CONTAINER_NAME: getRequiredStringEnv(
+      "USER_DATA_BACKUP_CONTAINER_NAME"
+    ),
+    USER_DATA_CONTAINER_NAME: getRequiredStringEnv("USER_DATA_CONTAINER_NAME"),
+
+    StorageConnection: getRequiredStringEnv("StorageConnection"),
+    SubscriptionFeedStorageConnection: getRequiredStringEnv(
+      "SubscriptionFeedStorageConnection"
+    ),
+    UserDataArchiveStorageConnection: getRequiredStringEnv(
+      "UserDataArchiveStorageConnection"
+    ),
+
+    PUBLIC_API_KEY: getRequiredStringEnv("PUBLIC_API_KEY"),
+    PUBLIC_API_URL: getRequiredStringEnv("PUBLIC_API_URL"),
+
+    PUBLIC_DOWNLOAD_BASE_URL: getRequiredStringEnv("PUBLIC_DOWNLOAD_BASE_URL"),
+
+    SESSION_API_KEY: getRequiredStringEnv("SESSION_API_KEY"),
+    SESSION_API_URL: getRequiredStringEnv("SESSION_API_URL"),
+
+    LOGOS_URL: getRequiredStringEnv("LOGOS_URL"),
+
+    SUBSCRIPTIONS_FEED_TABLE: getRequiredStringEnv("SUBSCRIPTIONS_FEED_TABLE"),
+    USER_DATA_DELETE_DELAY_DAYS: getRequiredStringEnv(
+      "USER_DATA_DELETE_DELAY_DAYS"
+    ),
+
+    // FIXME: email configuration values may be required or not depending on their values
+    // We
+    MAIL_FROM: getRequiredStringEnv("MAIL_FROM"),
+    MAIL_TRANSPORTS: process.env.MAIL_TRANSPORTS,
+
+    MAILHOG_HOSTNAME: process.env.MAILHOG_HOSTNAME,
+    MAILUP_SECRET: process.env.MAILUP_SECRET,
+    MAILUP_USERNAME: process.env.MAILUP_USERNAME,
+    SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
+
+    // Whether we're in a production environment
+    isProduction: process.env.NODE_ENV === "production"
+  };
+}

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,3 +1,4 @@
+import { MailMultiTransportConnectionsFromString } from "io-functions-commons/dist/src/utils/multi_transport_connection";
 /**
  * Config module
  *
@@ -9,59 +10,123 @@ import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
+export type NullableString = t.TypeOf<typeof NullableString>;
+const NullableString = t.union([t.string, t.undefined]);
+
+// explude a specific value from a type
+const AnyBut = <A, O = A>(but: A, base: t.Type<A, O> = t.any) =>
+  t.brand(
+    base,
+    (
+      s
+    ): s is t.Branded<
+      t.TypeOf<typeof base>,
+      { readonly AnyBut: unique symbol }
+    > => s !== but,
+    "AnyBut"
+  );
+
+// configuration to send email
+export type MailerConfig = t.TypeOf<typeof MailerConfig>;
+export const MailerConfig = t.intersection([
+  // common fields
+  t.interface({
+    MAIL_FROM: NonEmptyString
+  }),
+  // the following union includes the possible configuration variants for different mail transport we use in prod
+  // undefined values are kept for easy usage
+  t.union([
+    // Using sendgrid
+    t.interface({
+      NODE_ENV: t.literal("production"),
+      MAIL_TRANSPORTS: t.undefined,
+      SENDGRID_API_KEY: NonEmptyString,
+      MAILUP_USERNAME: t.undefined,
+      MAILUP_SECRET: t.undefined,
+      MAILHOG_HOSTNAME: t.undefined
+    }),
+    // using mailup
+    t.interface({
+      NODE_ENV: t.literal("production"),
+      MAIL_TRANSPORTS: t.undefined,
+      SENDGRID_API_KEY: t.undefined,
+      MAILUP_USERNAME: NonEmptyString,
+      MAILUP_SECRET: NonEmptyString,
+      MAILHOG_HOSTNAME: t.undefined
+    }),
+    // Using multi-transport definition
+    // Optional multi provider connection string
+    // The connection string must be in the format:
+    //   [mailup:username:password;][sendgrid:apikey:;]
+    // Note that multiple instances of the same provider can be provided.
+    t.interface({
+      NODE_ENV: t.literal("production"),
+      MAIL_TRANSPORTS: MailMultiTransportConnectionsFromString,
+      SENDGRID_API_KEY: t.undefined,
+      MAILUP_USERNAME: t.undefined,
+      MAILUP_SECRET: t.undefined,
+      MAILHOG_HOSTNAME: t.undefined
+    }),
+    t.interface({
+      // the following states that a mailhog configuration is optional and can be provided only if not in prod
+      NODE_ENV: AnyBut("production", NullableString),
+      MAILHOG_HOSTNAME: NonEmptyString,
+      MAIL_TRANSPORTS: t.undefined,
+      SENDGRID_API_KEY: t.undefined,
+      MAILUP_USERNAME: t.undefined,
+      MAILUP_SECRET: t.undefined
+    })
+  ])
+]);
+
+// global app configuration
 export type IConfig = t.TypeOf<typeof IConfig>;
-export const IConfig = t.interface({
-  COSMOSDB_KEY: NonEmptyString,
-  COSMOSDB_NAME: NonEmptyString,
-  COSMOSDB_URI: NonEmptyString,
+export const IConfig = t.intersection([
+  t.interface({
+    COSMOSDB_KEY: NonEmptyString,
+    COSMOSDB_NAME: NonEmptyString,
+    COSMOSDB_URI: NonEmptyString,
 
-  SERVICE_PRINCIPAL_CLIENT_ID: NonEmptyString,
-  SERVICE_PRINCIPAL_SECRET: NonEmptyString,
-  SERVICE_PRINCIPAL_TENANT_ID: NonEmptyString,
+    SERVICE_PRINCIPAL_CLIENT_ID: NonEmptyString,
+    SERVICE_PRINCIPAL_SECRET: NonEmptyString,
+    SERVICE_PRINCIPAL_TENANT_ID: NonEmptyString,
 
-  AZURE_APIM: NonEmptyString,
-  AZURE_APIM_HOST: NonEmptyString,
-  AZURE_APIM_RESOURCE_GROUP: NonEmptyString,
-  AZURE_SUBSCRIPTION_ID: NonEmptyString,
+    AZURE_APIM: NonEmptyString,
+    AZURE_APIM_HOST: NonEmptyString,
+    AZURE_APIM_RESOURCE_GROUP: NonEmptyString,
+    AZURE_SUBSCRIPTION_ID: NonEmptyString,
 
-  ADB2C_CLIENT_ID: NonEmptyString,
-  ADB2C_CLIENT_KEY: NonEmptyString,
-  ADB2C_TENANT_ID: NonEmptyString,
+    ADB2C_CLIENT_ID: NonEmptyString,
+    ADB2C_CLIENT_KEY: NonEmptyString,
+    ADB2C_TENANT_ID: NonEmptyString,
 
-  UserDataBackupStorageConnection: NonEmptyString,
+    UserDataBackupStorageConnection: NonEmptyString,
 
-  MESSAGE_CONTAINER_NAME: NonEmptyString,
-  USER_DATA_BACKUP_CONTAINER_NAME: NonEmptyString,
-  USER_DATA_CONTAINER_NAME: NonEmptyString,
+    MESSAGE_CONTAINER_NAME: NonEmptyString,
+    USER_DATA_BACKUP_CONTAINER_NAME: NonEmptyString,
+    USER_DATA_CONTAINER_NAME: NonEmptyString,
 
-  StorageConnection: NonEmptyString,
-  SubscriptionFeedStorageConnection: NonEmptyString,
-  UserDataArchiveStorageConnection: NonEmptyString,
+    StorageConnection: NonEmptyString,
+    SubscriptionFeedStorageConnection: NonEmptyString,
+    UserDataArchiveStorageConnection: NonEmptyString,
 
-  PUBLIC_API_KEY: NonEmptyString,
-  PUBLIC_API_URL: NonEmptyString,
+    PUBLIC_API_KEY: NonEmptyString,
+    PUBLIC_API_URL: NonEmptyString,
 
-  PUBLIC_DOWNLOAD_BASE_URL: NonEmptyString,
+    PUBLIC_DOWNLOAD_BASE_URL: NonEmptyString,
 
-  SESSION_API_KEY: NonEmptyString,
-  SESSION_API_URL: NonEmptyString,
+    SESSION_API_KEY: NonEmptyString,
+    SESSION_API_URL: NonEmptyString,
 
-  LOGOS_URL: NonEmptyString,
+    LOGOS_URL: NonEmptyString,
 
-  SUBSCRIPTIONS_FEED_TABLE: NonEmptyString,
-  USER_DATA_DELETE_DELAY_DAYS: NonEmptyString,
+    SUBSCRIPTIONS_FEED_TABLE: NonEmptyString,
+    USER_DATA_DELETE_DELAY_DAYS: NonEmptyString,
 
-  // FIXME: email configuration values may be required or not depending on their values
-  MAIL_FROM: NonEmptyString,
-  MAIL_TRANSPORTS: t.string,
-
-  MAILHOG_HOSTNAME: t.string,
-  MAILUP_SECRET: t.string,
-  MAILUP_USERNAME: t.string,
-  SENDGRID_API_KEY: t.string,
-
-  isProduction: t.boolean
-});
+    isProduction: t.boolean
+  }),
+  MailerConfig
+]);
 
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,77 +1,91 @@
+import { tryCatch2v } from "fp-ts/lib/Either";
+import { toError } from "fp-ts/lib/Either";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 
-export type IConfig = ReturnType<typeof getConfig>;
+export type IConfig = ReturnType<typeof getEnv>;
+
+// base read function
+// tslint:disable typedef
+const getEnv = () => ({
+  COSMOSDB_KEY: getRequiredStringEnv("COSMOSDB_KEY"),
+  COSMOSDB_NAME: getRequiredStringEnv("COSMOSDB_NAME"),
+  COSMOSDB_URI: getRequiredStringEnv("COSMOSDB_URI"),
+
+  SERVICE_PRINCIPAL_CLIENT_ID: getRequiredStringEnv(
+    "SERVICE_PRINCIPAL_CLIENT_ID"
+  ),
+  SERVICE_PRINCIPAL_SECRET: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
+  SERVICE_PRINCIPAL_TENANT_ID: getRequiredStringEnv(
+    "SERVICE_PRINCIPAL_TENANT_ID"
+  ),
+
+  AZURE_APIM: getRequiredStringEnv("AZURE_APIM"),
+  AZURE_APIM_HOST: getRequiredStringEnv("AZURE_APIM_HOST"),
+  AZURE_APIM_RESOURCE_GROUP: getRequiredStringEnv("AZURE_APIM_RESOURCE_GROUP"),
+  AZURE_SUBSCRIPTION_ID: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID"),
+
+  ADB2C_CLIENT_ID: getRequiredStringEnv("ADB2C_CLIENT_ID"),
+  ADB2C_CLIENT_KEY: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
+  ADB2C_TENANT_ID: getRequiredStringEnv("ADB2C_TENANT_ID"),
+
+  UserDataBackupStorageConnection: getRequiredStringEnv(
+    "UserDataBackupStorageConnection"
+  ),
+
+  MESSAGE_CONTAINER_NAME: getRequiredStringEnv("MESSAGE_CONTAINER_NAME"),
+  USER_DATA_BACKUP_CONTAINER_NAME: getRequiredStringEnv(
+    "USER_DATA_BACKUP_CONTAINER_NAME"
+  ),
+  USER_DATA_CONTAINER_NAME: getRequiredStringEnv("USER_DATA_CONTAINER_NAME"),
+
+  StorageConnection: getRequiredStringEnv("StorageConnection"),
+  SubscriptionFeedStorageConnection: getRequiredStringEnv(
+    "SubscriptionFeedStorageConnection"
+  ),
+  UserDataArchiveStorageConnection: getRequiredStringEnv(
+    "UserDataArchiveStorageConnection"
+  ),
+
+  PUBLIC_API_KEY: getRequiredStringEnv("PUBLIC_API_KEY"),
+  PUBLIC_API_URL: getRequiredStringEnv("PUBLIC_API_URL"),
+
+  PUBLIC_DOWNLOAD_BASE_URL: getRequiredStringEnv("PUBLIC_DOWNLOAD_BASE_URL"),
+
+  SESSION_API_KEY: getRequiredStringEnv("SESSION_API_KEY"),
+  SESSION_API_URL: getRequiredStringEnv("SESSION_API_URL"),
+
+  LOGOS_URL: getRequiredStringEnv("LOGOS_URL"),
+
+  SUBSCRIPTIONS_FEED_TABLE: getRequiredStringEnv("SUBSCRIPTIONS_FEED_TABLE"),
+  USER_DATA_DELETE_DELAY_DAYS: getRequiredStringEnv(
+    "USER_DATA_DELETE_DELAY_DAYS"
+  ),
+
+  // FIXME: email configuration values may be required or not depending on their values
+  // We
+  MAIL_FROM: getRequiredStringEnv("MAIL_FROM"),
+  MAIL_TRANSPORTS: process.env.MAIL_TRANSPORTS,
+
+  MAILHOG_HOSTNAME: process.env.MAILHOG_HOSTNAME,
+  MAILUP_SECRET: process.env.MAILUP_SECRET,
+  MAILUP_USERNAME: process.env.MAILUP_USERNAME,
+  SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
+
+  // Whether we're in a production environment
+  isProduction: process.env.NODE_ENV === "production"
+});
+
+// No need to re-evaluate this object for each call
+const errorOrConfig = tryCatch2v(getEnv, toError);
 
 // tslint:disable typedef
 export function getConfig() {
-  return {
-    COSMOSDB_KEY: getRequiredStringEnv("COSMOSDB_KEY"),
-    COSMOSDB_NAME: getRequiredStringEnv("COSMOSDB_NAME"),
-    COSMOSDB_URI: getRequiredStringEnv("COSMOSDB_URI"),
+  return errorOrConfig;
+}
 
-    SERVICE_PRINCIPAL_CLIENT_ID: getRequiredStringEnv(
-      "SERVICE_PRINCIPAL_CLIENT_ID"
-    ),
-    SERVICE_PRINCIPAL_SECRET: getRequiredStringEnv("SERVICE_PRINCIPAL_SECRET"),
-    SERVICE_PRINCIPAL_TENANT_ID: getRequiredStringEnv(
-      "SERVICE_PRINCIPAL_TENANT_ID"
-    ),
-
-    AZURE_APIM: getRequiredStringEnv("AZURE_APIM"),
-    AZURE_APIM_HOST: getRequiredStringEnv("AZURE_APIM_HOST"),
-    AZURE_APIM_RESOURCE_GROUP: getRequiredStringEnv(
-      "AZURE_APIM_RESOURCE_GROUP"
-    ),
-    AZURE_SUBSCRIPTION_ID: getRequiredStringEnv("AZURE_SUBSCRIPTION_ID"),
-
-    ADB2C_CLIENT_ID: getRequiredStringEnv("ADB2C_CLIENT_ID"),
-    ADB2C_CLIENT_KEY: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
-    ADB2C_TENANT_ID: getRequiredStringEnv("ADB2C_TENANT_ID"),
-
-    UserDataBackupStorageConnection: getRequiredStringEnv(
-      "UserDataBackupStorageConnection"
-    ),
-
-    MESSAGE_CONTAINER_NAME: getRequiredStringEnv("MESSAGE_CONTAINER_NAME"),
-    USER_DATA_BACKUP_CONTAINER_NAME: getRequiredStringEnv(
-      "USER_DATA_BACKUP_CONTAINER_NAME"
-    ),
-    USER_DATA_CONTAINER_NAME: getRequiredStringEnv("USER_DATA_CONTAINER_NAME"),
-
-    StorageConnection: getRequiredStringEnv("StorageConnection"),
-    SubscriptionFeedStorageConnection: getRequiredStringEnv(
-      "SubscriptionFeedStorageConnection"
-    ),
-    UserDataArchiveStorageConnection: getRequiredStringEnv(
-      "UserDataArchiveStorageConnection"
-    ),
-
-    PUBLIC_API_KEY: getRequiredStringEnv("PUBLIC_API_KEY"),
-    PUBLIC_API_URL: getRequiredStringEnv("PUBLIC_API_URL"),
-
-    PUBLIC_DOWNLOAD_BASE_URL: getRequiredStringEnv("PUBLIC_DOWNLOAD_BASE_URL"),
-
-    SESSION_API_KEY: getRequiredStringEnv("SESSION_API_KEY"),
-    SESSION_API_URL: getRequiredStringEnv("SESSION_API_URL"),
-
-    LOGOS_URL: getRequiredStringEnv("LOGOS_URL"),
-
-    SUBSCRIPTIONS_FEED_TABLE: getRequiredStringEnv("SUBSCRIPTIONS_FEED_TABLE"),
-    USER_DATA_DELETE_DELAY_DAYS: getRequiredStringEnv(
-      "USER_DATA_DELETE_DELAY_DAYS"
-    ),
-
-    // FIXME: email configuration values may be required or not depending on their values
-    // We
-    MAIL_FROM: getRequiredStringEnv("MAIL_FROM"),
-    MAIL_TRANSPORTS: process.env.MAIL_TRANSPORTS,
-
-    MAILHOG_HOSTNAME: process.env.MAILHOG_HOSTNAME,
-    MAILUP_SECRET: process.env.MAILUP_SECRET,
-    MAILUP_USERNAME: process.env.MAILUP_USERNAME,
-    SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
-
-    // Whether we're in a production environment
-    isProduction: process.env.NODE_ENV === "production"
-  };
+// tslint:disable typedef
+export function getConfigOrThrow() {
+  return errorOrConfig.getOrElseL(error => {
+    throw new Error(`Invalid configuration: ${error.message}`);
+  });
 }

--- a/utils/cosmosdb.ts
+++ b/utils/cosmosdb.ts
@@ -2,11 +2,11 @@
  * Use a singleton CosmosDB client across functions.
  */
 import { CosmosClient } from "@azure/cosmos";
+import { getConfig } from "./config";
 
-import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
-
-const cosmosDbUri = getRequiredStringEnv("COSMOSDB_URI");
-const masterKey = getRequiredStringEnv("COSMOSDB_KEY");
+const config = getConfig();
+const cosmosDbUri = config.COSMOSDB_URI;
+const masterKey = config.COSMOSDB_KEY;
 
 export const cosmosdbClient = new CosmosClient({
   endpoint: cosmosDbUri,

--- a/utils/cosmosdb.ts
+++ b/utils/cosmosdb.ts
@@ -2,9 +2,9 @@
  * Use a singleton CosmosDB client across functions.
  */
 import { CosmosClient } from "@azure/cosmos";
-import { getConfig } from "./config";
+import { getConfigOrThrow } from "./config";
 
-const config = getConfig();
+const config = getConfigOrThrow();
 const cosmosDbUri = config.COSMOSDB_URI;
 const masterKey = config.COSMOSDB_KEY;
 

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -17,6 +17,7 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as NodeMailer from "nodemailer";
 import nodemailerSendgrid = require("nodemailer-sendgrid");
 import Mail = require("nodemailer/lib/mailer");
+import { getConfig } from "./config";
 
 // 5 seconds timeout by default
 const DEFAULT_EMAIL_REQUEST_TIMEOUT_MS = 5000;
@@ -42,6 +43,7 @@ type MailTransportOptions = (IMailUpOptions | ISendGridOptions) & {
 };
 
 export function getMailerTransporter(opts: MailTransportOptions): Mail {
+  const config = getConfig();
   return opts.isProduction
     ? NodeMailer.createTransport(
         "sendgridApiKey" in opts
@@ -60,7 +62,7 @@ export function getMailerTransporter(opts: MailTransportOptions): Mail {
     : // For development we use mailhog to intercept emails
       // Use the `docker-compose.yml` file to run the mailhog server
       NodeMailer.createTransport({
-        host: process.env.MAILHOG_HOSTNAME || "localhost",
+        host: config.MAILHOG_HOSTNAME || "localhost",
         port: 1025,
         secure: false
       });

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -17,7 +17,7 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as NodeMailer from "nodemailer";
 import nodemailerSendgrid = require("nodemailer-sendgrid");
 import Mail = require("nodemailer/lib/mailer");
-import { getConfig } from "./config";
+import { getConfigOrThrow } from "./config";
 
 // 5 seconds timeout by default
 const DEFAULT_EMAIL_REQUEST_TIMEOUT_MS = 5000;
@@ -43,7 +43,7 @@ type MailTransportOptions = (IMailUpOptions | ISendGridOptions) & {
 };
 
 export function getMailerTransporter(opts: MailTransportOptions): Mail {
-  const config = getConfig();
+  const config = getConfigOrThrow();
   return opts.isProduction
     ? NodeMailer.createTransport(
         "sendgridApiKey" in opts


### PR DESCRIPTION
This PR introduces the `utils/config` module which aims to be the unique interface for application configuration. 

Every place in which the application used to directly access env variable has been refactored to use this module instead.