### PR TITLE
[#175170499] Add missing unauthorized to openapi specs

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -328,6 +328,8 @@ paths:
             $ref: "#/definitions/UserInfo"
         "400":
           description: Bad request
+        "401":
+          description: Unauthorized
         "403":
           description: Forbidden
         "404":
@@ -393,6 +395,8 @@ paths:
             $ref: "#/definitions/Subscription"
         "400":
           description: Bad request
+        "401":
+          description: Unauthorized
         "403":
           description: Forbidden
         "404":

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -360,6 +360,8 @@ paths:
             $ref: "#/definitions/GroupCollection"
         "400":
           description: Bad request
+        "401":
+          description: Unauthorized
         "403":
           description: Forbidden
         "404":


### PR DESCRIPTION
This PR adds missing unauthorized response to operations that could return 401, with focus on `GetUser` and `CreateSubscription`