### PR TITLE
[#175227073] Allow updating ADB2C User and introduce Token Name management on Create/Update operations

### DIFF
--- a/CreateUser/__tests__/handler.ts
+++ b/CreateUser/__tests__/handler.ts
@@ -5,6 +5,7 @@ import { GraphRbacManagementClient } from "@azure/graph";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { left } from "fp-ts/lib/Either";
 import { fromEither, fromLeft } from "fp-ts/lib/TaskEither";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { User } from "../../generated/definitions/User";
 import { UserPayload } from "../../generated/definitions/UserPayload";
 import { UserStateEnum } from "../../generated/definitions/UserState";
@@ -64,7 +65,9 @@ mockApiManagementClient.mockImplementation(() => ({
   }
 }));
 
+const fakeAdb2cExtensionAppClientId = "extension-client-id" as NonEmptyString;
 const mockedContext = { log: { error: mockLog } };
+
 describe("CreateUser", () => {
   it("should return an internal error response if the ADB2C client can not be got", async () => {
     mockLoginWithServicePrincipalSecret.mockImplementationOnce(() =>
@@ -74,7 +77,8 @@ describe("CreateUser", () => {
     const createUserHandler = CreateUserHandler(
       fakeServicePrincipalCredentials,
       fakeServicePrincipalCredentials,
-      fakeApimConfig
+      fakeApimConfig,
+      fakeAdb2cExtensionAppClientId
     );
 
     const response = await createUserHandler(
@@ -94,7 +98,8 @@ describe("CreateUser", () => {
     const createUserHandler = CreateUserHandler(
       fakeServicePrincipalCredentials,
       fakeServicePrincipalCredentials,
-      fakeApimConfig
+      fakeApimConfig,
+      fakeAdb2cExtensionAppClientId
     );
 
     const response = await createUserHandler(
@@ -119,7 +124,8 @@ describe("CreateUser", () => {
     const createUserHandler = CreateUserHandler(
       fakeServicePrincipalCredentials,
       fakeServicePrincipalCredentials,
-      fakeApimConfig
+      fakeApimConfig,
+      fakeAdb2cExtensionAppClientId
     );
 
     const response = await createUserHandler(
@@ -142,7 +148,8 @@ describe("CreateUser", () => {
     const createUserHandler = CreateUserHandler(
       fakeServicePrincipalCredentials,
       fakeServicePrincipalCredentials,
-      fakeApimConfig
+      fakeApimConfig,
+      fakeAdb2cExtensionAppClientId
     );
 
     const response = await createUserHandler(
@@ -187,7 +194,8 @@ describe("CreateUser", () => {
     const createUserHandler = CreateUserHandler(
       fakeServicePrincipalCredentials,
       fakeServicePrincipalCredentials,
-      fakeApimConfig
+      fakeApimConfig,
+      fakeAdb2cExtensionAppClientId
     );
 
     const response = await createUserHandler(

--- a/UpdateUser/__tests__/handler.ts
+++ b/UpdateUser/__tests__/handler.ts
@@ -3,9 +3,11 @@
 import { GraphRbacManagementClient } from "@azure/graph";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { EmailAddress } from "../../generated/definitions/EmailAddress";
 import { UserCreated } from "../../generated/definitions/UserCreated";
 import { UserPayload } from "../../generated/definitions/UserPayload";
 import { UserStateEnum } from "../../generated/definitions/UserState";
+import { UserUpdatePayload } from "../../generated/definitions/UserUpdatePayload";
 import { IServicePrincipalCreds } from "../../utils/apim";
 import { UpdateUserHandler } from "../handler";
 
@@ -16,12 +18,12 @@ const fakeServicePrincipalCredentials: IServicePrincipalCreds = {
   tenantId: "tenant-id"
 };
 
+const aUserEmail = "user@example.com" as EmailAddress;
 const fakeRequestPayload = {
-  email: "user@example.com",
   first_name: "first-name",
   last_name: "family-name",
   token_name: aTokenName
-} as UserPayload;
+} as UserUpdatePayload;
 
 const fakeObjectId = "ADB2C-user";
 
@@ -75,6 +77,7 @@ describe("UpdateUser", () => {
     const response = await updateUserHandler(
       mockedContext as any,
       undefined as any,
+      undefined as any,
       undefined as any
     );
 
@@ -94,6 +97,7 @@ describe("UpdateUser", () => {
     const response = await updateUserHandler(
       mockedContext as any,
       undefined as any,
+      aUserEmail,
       fakeRequestPayload
     );
 
@@ -102,7 +106,7 @@ describe("UpdateUser", () => {
 
   it("should return the user updated", async () => {
     const fakeApimUser = {
-      email: fakeRequestPayload.email,
+      email: aUserEmail,
       firstName: fakeRequestPayload.first_name,
       id: "user-id",
       identities: [
@@ -136,6 +140,7 @@ describe("UpdateUser", () => {
     const response = await updateUserHandler(
       mockedContext as any,
       undefined as any,
+      aUserEmail,
       fakeRequestPayload
     );
     expect(response).toEqual({

--- a/UpdateUser/__tests__/handler.ts
+++ b/UpdateUser/__tests__/handler.ts
@@ -5,7 +5,6 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { EmailAddress } from "../../generated/definitions/EmailAddress";
 import { UserCreated } from "../../generated/definitions/UserCreated";
-import { UserPayload } from "../../generated/definitions/UserPayload";
 import { UserStateEnum } from "../../generated/definitions/UserState";
 import { UserUpdatePayload } from "../../generated/definitions/UserUpdatePayload";
 import { IServicePrincipalCreds } from "../../utils/apim";

--- a/UpdateUser/__tests__/handler.ts
+++ b/UpdateUser/__tests__/handler.ts
@@ -1,0 +1,147 @@
+// tslint:disable:no-any
+
+import { GraphRbacManagementClient } from "@azure/graph";
+import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { UserCreated } from "../../generated/definitions/UserCreated";
+import { UserPayload } from "../../generated/definitions/UserPayload";
+import { UserStateEnum } from "../../generated/definitions/UserState";
+import { IServicePrincipalCreds } from "../../utils/apim";
+import { UpdateUserHandler } from "../handler";
+
+const aTokenName = "ATokenName" as NonEmptyString;
+const fakeServicePrincipalCredentials: IServicePrincipalCreds = {
+  clientId: "client-id",
+  secret: "secret",
+  tenantId: "tenant-id"
+};
+
+const fakeRequestPayload = {
+  email: "user@example.com",
+  first_name: "first-name",
+  last_name: "family-name",
+  token_name: aTokenName
+} as UserPayload;
+
+const fakeObjectId = "ADB2C-user";
+
+const mockLoginWithServicePrincipalSecret = jest.spyOn(
+  msRestNodeAuth,
+  "loginWithServicePrincipalSecret"
+);
+
+jest.mock("@azure/graph");
+jest.mock("@azure/arm-apimanagement");
+const mockGraphRbacManagementClient = GraphRbacManagementClient as jest.Mock;
+const mockLog = jest.fn();
+const mockGetToken = jest.fn();
+
+mockLoginWithServicePrincipalSecret.mockImplementation(() => {
+  return Promise.resolve({ getToken: mockGetToken });
+});
+mockGetToken.mockImplementation(() => {
+  return Promise.resolve(undefined);
+});
+const mockUsersCreate = jest.fn();
+
+mockGraphRbacManagementClient.mockImplementation(() => ({
+  users: {
+    list: jest.fn(() =>
+      Promise.resolve([
+        {
+          email: "user@example.com"
+        }
+      ])
+    ),
+    update: mockUsersCreate
+  }
+}));
+
+const fakeAdb2cExtensionAppClientId = "extension-client-id" as NonEmptyString;
+
+const mockedContext = { log: { error: mockLog } };
+
+describe("UpdateUser", () => {
+  it("should return an internal error response if the ADB2C client can not be got", async () => {
+    mockLoginWithServicePrincipalSecret.mockImplementationOnce(() =>
+      Promise.reject("Error from ApiManagementClient constructor")
+    );
+
+    const updateUserHandler = UpdateUserHandler(
+      fakeServicePrincipalCredentials,
+      fakeAdb2cExtensionAppClientId
+    );
+
+    const response = await updateUserHandler(
+      mockedContext as any,
+      undefined as any,
+      undefined as any
+    );
+
+    expect(response.kind).toEqual("IResponseErrorInternal");
+  });
+
+  it("should return an internal error response if the ADB2C client can not update the user", async () => {
+    mockUsersCreate.mockImplementationOnce(() =>
+      Promise.reject("Users update error")
+    );
+
+    const updateUserHandler = UpdateUserHandler(
+      fakeServicePrincipalCredentials,
+      fakeAdb2cExtensionAppClientId
+    );
+
+    const response = await updateUserHandler(
+      mockedContext as any,
+      undefined as any,
+      fakeRequestPayload
+    );
+
+    expect(response.kind).toEqual("IResponseErrorInternal");
+  });
+
+  it("should return the user updated", async () => {
+    const fakeApimUser = {
+      email: fakeRequestPayload.email,
+      firstName: fakeRequestPayload.first_name,
+      id: "user-id",
+      identities: [
+        {
+          id: fakeObjectId,
+          provider: "AadB2C"
+        }
+      ],
+      lastName: fakeRequestPayload.last_name,
+      name: fakeObjectId,
+      registrationDate: new Date(),
+      state: UserStateEnum.active,
+      type: "Microsoft.ApiManagement/service/users"
+    };
+    const expectedUpdatedUser: UserCreated = {
+      email: fakeApimUser.email,
+      first_name: fakeApimUser.firstName,
+      id: fakeApimUser.name,
+      last_name: fakeApimUser.lastName,
+      token_name: aTokenName
+    };
+    mockUsersCreate.mockImplementationOnce(() =>
+      Promise.resolve({ objectId: fakeObjectId })
+    );
+
+    const updateUserHandler = UpdateUserHandler(
+      fakeServicePrincipalCredentials,
+      fakeAdb2cExtensionAppClientId
+    );
+
+    const response = await updateUserHandler(
+      mockedContext as any,
+      undefined as any,
+      fakeRequestPayload
+    );
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      kind: "IResponseSuccessJson",
+      value: expectedUpdatedUser
+    });
+  });
+});

--- a/UpdateUser/function.json
+++ b/UpdateUser/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "adm/users",
+      "methods": [
+        "put"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/UpdateUser/index.js"
+}

--- a/UpdateUser/function.json
+++ b/UpdateUser/function.json
@@ -5,7 +5,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "route": "adm/users",
+      "route": "adm/users/{email}",
       "methods": [
         "put"
       ]

--- a/UpdateUser/handler.ts
+++ b/UpdateUser/handler.ts
@@ -5,6 +5,7 @@ import * as express from "express";
 import { toError } from "fp-ts/lib/Either";
 import { identity } from "fp-ts/lib/function";
 import { fromLeft } from "fp-ts/lib/TaskEither";
+import { fromEither } from "fp-ts/lib/TaskEither";
 import { taskEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import {
   AzureApiAuthMiddleware,
@@ -71,13 +72,15 @@ const updateUser = (
       ),
     toError
   ).chain(updateUserResponse =>
-    UserCreated.decode({
-      email,
-      first_name: userPayload.first_name || user.givenName,
-      id: updateUserResponse.objectId,
-      last_name: userPayload.last_name || user.surname,
-      token_name: userPayload.token_name
-    }).fold(errs => fromLeft(toError(errs)), usr => taskEither.of(usr))
+    fromEither(
+      UserCreated.decode({
+        email,
+        first_name: userPayload.first_name || user.givenName,
+        id: updateUserResponse.objectId,
+        last_name: userPayload.last_name || user.surname,
+        token_name: userPayload.token_name
+      }).mapLeft(toError)
+    )
   );
 
 export function UpdateUserHandler(

--- a/UpdateUser/handler.ts
+++ b/UpdateUser/handler.ts
@@ -1,0 +1,133 @@
+import { Context } from "@azure/functions";
+import { GraphRbacManagementClient } from "@azure/graph";
+import * as express from "express";
+import { toError } from "fp-ts/lib/Either";
+import { identity } from "fp-ts/lib/function";
+import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import {
+  AzureApiAuthMiddleware,
+  IAzureApiAuthorization,
+  UserGroup
+} from "io-functions-commons/dist/src/utils/middlewares/azure_api_auth";
+import { ContextMiddleware } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredBodyPayloadMiddleware } from "io-functions-commons/dist/src/utils/middlewares/required_body_payload";
+import { withRequestMiddlewares } from "io-functions-commons/dist/src/utils/request_middleware";
+import { wrapRequestHandler } from "italia-ts-commons/lib/request_middleware";
+import {
+  IResponseErrorInternal,
+  IResponseSuccessJson,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { withoutUndefinedValues } from "italia-ts-commons/lib/types";
+import { UserCreated } from "../generated/definitions/UserCreated";
+import { UserPayload } from "../generated/definitions/UserPayload";
+import {
+  getGraphRbacManagementClient,
+  IServicePrincipalCreds
+} from "../utils/apim";
+import { genericInternalErrorHandler } from "../utils/errorHandler";
+
+type IUpdateUserHandler = (
+  context: Context,
+  auth: IAzureApiAuthorization,
+  userPayload: UserPayload
+) => Promise<IResponseSuccessJson<UserCreated> | IResponseErrorInternal>;
+
+const getUserFromList = (client: GraphRbacManagementClient, email: string) =>
+  tryCatch(
+    () =>
+      client.users.list({
+        filter: `signInNames/any(x:x/value eq '${email}')`
+      }),
+    toError
+  ).map(userList => userList[0]);
+
+const updateUser = (
+  client: GraphRbacManagementClient,
+  userPrincipalName: string,
+  adb2cTokenAttributeName: string,
+  userPayload: UserPayload
+): TaskEither<Error, UserCreated> =>
+  tryCatch(
+    () =>
+      client.users.update(
+        userPrincipalName,
+        withoutUndefinedValues({
+          displayName: `${userPayload.first_name} ${userPayload.last_name}`,
+          givenName: userPayload.first_name,
+          mailNickname: userPayload.email.split("@")[0],
+          surname: userPayload.last_name,
+          [adb2cTokenAttributeName]: userPayload.token_name
+        })
+      ),
+    toError
+  ).map(
+    updateUserResponse =>
+      ({
+        ...userPayload,
+        id: updateUserResponse.objectId
+      } as UserCreated)
+  );
+
+export function UpdateUserHandler(
+  adb2cCredentials: IServicePrincipalCreds,
+  adb2cTokenAttributeName: NonEmptyString
+): IUpdateUserHandler {
+  return async (context, _, userPayload) => {
+    const internalErrorHandler = (errorMessage: string, error: Error) =>
+      genericInternalErrorHandler(
+        context,
+        "UpdateUser | " + errorMessage,
+        error,
+        errorMessage
+      );
+    return getGraphRbacManagementClient(adb2cCredentials)
+      .mapLeft(error =>
+        internalErrorHandler("Could not get the ADB2C client", error)
+      )
+      .chain(graphRbacManagementClient =>
+        getUserFromList(graphRbacManagementClient, userPayload.email)
+          .chain(user =>
+            updateUser(
+              graphRbacManagementClient,
+              user.userPrincipalName,
+              adb2cTokenAttributeName,
+              userPayload
+            )
+          )
+          .mapLeft(error =>
+            internalErrorHandler(
+              "Could not update the user on the ADB2C",
+              error
+            )
+          )
+      )
+      .fold<IResponseSuccessJson<UserCreated> | IResponseErrorInternal>(
+        identity,
+        updatedUser => ResponseSuccessJson(updatedUser)
+      )
+      .run();
+  };
+}
+
+/**
+ * Wraps an UpdateUser handler inside an Express request handler.
+ */
+export function UpdateUser(
+  adb2cCreds: IServicePrincipalCreds,
+  adb2cTokenAttributeName: NonEmptyString
+): express.RequestHandler {
+  const handler = UpdateUserHandler(adb2cCreds, adb2cTokenAttributeName);
+
+  const middlewaresWrap = withRequestMiddlewares(
+    // Extract Azure Functions bindings
+    ContextMiddleware(),
+    // Allow only users in the ApiUserAdmin group
+    AzureApiAuthMiddleware(new Set([UserGroup.ApiUserAdmin])),
+    // Extract the body payload from the request
+    RequiredBodyPayloadMiddleware(UserPayload)
+  );
+
+  return wrapRequestHandler(middlewaresWrap(handler));
+}

--- a/UpdateUser/handler.ts
+++ b/UpdateUser/handler.ts
@@ -4,8 +4,7 @@ import { User } from "@azure/graph/esm/models";
 import * as express from "express";
 import { toError } from "fp-ts/lib/Either";
 import { identity } from "fp-ts/lib/function";
-import { fromEither } from "fp-ts/lib/TaskEither";
-import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { fromEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import {
   AzureApiAuthMiddleware,
   IAzureApiAuthorization,

--- a/UpdateUser/index.ts
+++ b/UpdateUser/index.ts
@@ -11,25 +11,13 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
 import { getConfigOrThrow } from "../utils/config";
-import { CreateUser } from "./handler";
+import { UpdateUser } from "./handler";
 
 const config = getConfigOrThrow();
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
   secret: getRequiredStringEnv("ADB2C_CLIENT_KEY"),
   tenantId: getRequiredStringEnv("ADB2C_TENANT_ID")
-};
-
-const servicePrincipalCreds = {
-  clientId: config.SERVICE_PRINCIPAL_CLIENT_ID,
-  secret: config.SERVICE_PRINCIPAL_SECRET,
-  tenantId: config.SERVICE_PRINCIPAL_TENANT_ID
-};
-
-const azureApimConfig = {
-  apim: config.AZURE_APIM,
-  apimResourceGroup: config.AZURE_APIM_RESOURCE_GROUP,
-  subscriptionId: config.AZURE_SUBSCRIPTION_ID
 };
 
 const adb2cTokenAttributeName = getRequiredStringEnv(
@@ -48,15 +36,7 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.post(
-  "/adm/users",
-  CreateUser(
-    adb2cCreds,
-    servicePrincipalCreds,
-    azureApimConfig,
-    adb2cTokenAttributeName
-  )
-);
+app.put("/adm/users", UpdateUser(adb2cCreds, adb2cTokenAttributeName));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/UpdateUser/index.ts
+++ b/UpdateUser/index.ts
@@ -34,7 +34,7 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.put("/adm/users", UpdateUser(adb2cCreds, adb2cTokenAttributeName));
+app.put("/adm/users/:email", UpdateUser(adb2cCreds, adb2cTokenAttributeName));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/UpdateUser/index.ts
+++ b/UpdateUser/index.ts
@@ -10,10 +10,8 @@ import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/c
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
-import { getConfigOrThrow } from "../utils/config";
 import { UpdateUser } from "./handler";
 
-const config = getConfigOrThrow();
 const adb2cCreds = {
   clientId: getRequiredStringEnv("ADB2C_CLIENT_ID"),
   secret: getRequiredStringEnv("ADB2C_CLIENT_KEY"),

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -356,7 +356,7 @@ paths:
         "200":
           description: The updated User
           schema:
-            $ref: "#/definitions/UserCreated"
+            $ref: "#/definitions/UserUpdated"
         "400":
           description: Bad request
         "403":

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -309,27 +309,6 @@ paths:
           description: Forbidden
         "500":
           description: Internal server error
-    put:
-      summary: Update user
-      description: Update an existing ADB2C User.
-      operationId: updateUser
-      parameters:
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: "#/definitions/UserPayload"
-      responses:
-        "200":
-          description: The updated User
-          schema:
-            $ref: "#/definitions/UserCreated"
-        "400":
-          description: Bad request
-        "403":
-          description: Forbidden
-        "500":
-          description: Internal server error
   /users/{email}:
     get:
       summary: Get user
@@ -355,6 +334,33 @@ paths:
           description: Forbidden
         "404":
           description: User not found
+        "500":
+          description: Internal server error
+    put:
+      summary: Update user
+      description: Update an existing ADB2C User.
+      operationId: updateUser
+      parameters:
+        - name: email
+          in: path
+          type: string
+          format: email
+          required: true
+          description: The email of the User
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/UserUpdatePayload"
+      responses:
+        "200":
+          description: The updated User
+          schema:
+            $ref: "#/definitions/UserCreated"
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
         "500":
           description: Internal server error
   /users/{email}/groups:
@@ -511,6 +517,18 @@ definitions:
       - email
       - first_name
       - last_name
+  UserUpdatePayload:
+    type: object
+    properties:
+      first_name:
+        type: string
+        minLength: 1
+      last_name:
+        type: string
+        minLength: 1
+      token_name:
+        type: string
+        minLength: 1
   UserCreated:
     allOf:
       - $ref: "#/definitions/UserPayload"

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -309,6 +309,27 @@ paths:
           description: Forbidden
         "500":
           description: Internal server error
+    put:
+      summary: Update user
+      description: Update an existing ADB2C User.
+      operationId: updateUser
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/UserPayload"
+      responses:
+        "200":
+          description: The updated User
+          schema:
+            $ref: "#/definitions/UserCreated"
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
+        "500":
+          description: Internal server error
   /users/{email}:
     get:
       summary: Get user
@@ -481,6 +502,9 @@ definitions:
         type: string
         minLength: 1
       last_name:
+        type: string
+        minLength: 1
+      token_name:
         type: string
         minLength: 1
     required:

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -538,6 +538,18 @@ definitions:
             type: string
         required:
           - id
+  UserUpdated:
+    allOf:
+      - $ref: "#/definitions/UserUpdatePayload"
+      - type: object
+        properties:
+          email:
+            $ref: "#/definitions/EmailAddress"
+          id:
+            type: string
+        required:
+          - id
+          - email
   GroupCollection:
     type: object
     properties:


### PR DESCRIPTION
This PR is intended to manage ADB2C custom attribute `Token Name`, in order to allow existing `CreateUser` and the brand new `UpdateUser` to manage this custom attribute.