### PR TITLE
[#175333306] Random charset to be 7bit ASCII collection

### DIFF
--- a/utils/random.ts
+++ b/utils/random.ts
@@ -7,8 +7,9 @@ import { readableReport } from "italia-ts-commons/lib/reporters";
 import { WithinRangeString } from "italia-ts-commons/lib/strings";
 import * as randomstring from "randomstring";
 
+/* printable 7 bit ASCII, some special char removed */
 const RANDOM_CHARSET =
-  "ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz0123456789!£$%&()?+@=€";
+  "ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz0123456789!#$%&()*+-/=?@";
 
 export const StrongPassword = WithinRangeString(18, 19);
 export type StrongPassword = t.TypeOf<typeof StrongPassword>;


### PR DESCRIPTION
This change is needed because windows systems fails to unzip an authenticated archive when password has certain characters. 

The solution is to use only a subset of 7bit ASCII characters which are also easy to read by humans.