### PR TITLE
[#175374436] Allow lowercase transformation on png naming while uploading a Service image Logo

### DIFF
--- a/UploadServiceLogo/__test__/handler.test.ts
+++ b/UploadServiceLogo/__test__/handler.test.ts
@@ -78,7 +78,7 @@ describe("UpdateServiceLogoHandler", () => {
 
     const blobServiceMock = ({
       createBlockBlobFromText: jest.fn((_, __, ___, cb) => {
-        return Promise.resolve(some({}));
+        return cb(null, "any");
       })
     } as any) as BlobService;
     const aServiceId = "1" as NonEmptyString;

--- a/UploadServiceLogo/__test__/handler.test.ts
+++ b/UploadServiceLogo/__test__/handler.test.ts
@@ -122,9 +122,7 @@ describe("UpdateServiceLogoHandler", () => {
       })
     };
     const blobServiceMock = ({
-      createBlockBlobFromText: jest.fn((_, __, ___, ____, cb) =>
-        cb(null, "any")
-      )
+      createBlockBlobFromText: jest.fn((_, __, ___, cb) => cb(null, "any"))
     } as any) as BlobService;
     const updateServiceLogoHandler = UpdateServiceLogoHandler(
       mockServiceModel as any,
@@ -159,9 +157,7 @@ describe("UpdateServiceLogoHandler", () => {
       })
     };
     const blobServiceMock = ({
-      createBlockBlobFromText: jest.fn((_, __, ___, ____, cb) =>
-        cb("any", null)
-      )
+      createBlockBlobFromText: jest.fn((_, __, ___, cb) => cb("any", null))
     } as any) as BlobService;
     const updateServiceLogoHandler = UpdateServiceLogoHandler(
       mockServiceModel as any,

--- a/UploadServiceLogo/function.json
+++ b/UploadServiceLogo/function.json
@@ -14,13 +14,6 @@
       "type": "http",
       "direction": "out",
       "name": "res"
-    },
-    {
-      "type": "blob",
-      "name": "logo",
-      "path": "services/{serviceId}.png",
-      "connection": "AssetsStorageConnection",
-      "direction": "out"
     }
   ],
   "scriptFile": "../dist/UploadServiceLogo/index.js"

--- a/UploadServiceLogo/handler.ts
+++ b/UploadServiceLogo/handler.ts
@@ -106,6 +106,7 @@ export function UpdateServiceLogoHandler(
     }
 
     const bufferImage = Buffer.from(logoPayload.logo, "base64");
+    const lowerCaseServiceId = serviceId.toLowerCase();
     return fromEither(
       tryCatch(() => UPNG.decode(bufferImage)).foldL(
         () =>
@@ -130,7 +131,7 @@ export function UpdateServiceLogoHandler(
           tUpsertBlobFromObject(
             blobService,
             "services",
-            `${serviceId.toLowerCase()}.png`,
+            `${lowerCaseServiceId}.png`,
             bufferImage.toString()
           )
             .mapLeft(err =>
@@ -150,7 +151,7 @@ export function UpdateServiceLogoHandler(
                   taskEither.of(
                     ResponseSuccessRedirectToResource(
                       {},
-                      `${logosUrl}/services/${serviceId.toLowerCase()}.png`,
+                      `${logosUrl}/services/${lowerCaseServiceId}.png`,
                       {}
                     )
                   )

--- a/UploadServiceLogo/handler.ts
+++ b/UploadServiceLogo/handler.ts
@@ -86,7 +86,7 @@ export function UpdateServiceLogoHandler(
   blobService: BlobService,
   logosUrl: string
 ): IUpdateServiceHandler {
-  return async (context, _, serviceId, logoPayload) => {
+  return async (_, __, serviceId, logoPayload) => {
     const errorOrMaybeRetrievedService = await serviceModel
       .findOneByServiceId(serviceId)
       .run();

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -15,6 +15,7 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { UploadServiceLogo } from "./handler";
 
+import { createBlobService } from "azure-storage";
 import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
 
@@ -26,6 +27,8 @@ const logosUrl = config.LOGOS_URL;
 const servicesContainer = database.container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);
+
+const blobService = createBlobService(config.StorageConnection);
 
 // tslint:disable-next-line: no-let
 let logger: Context["log"] | undefined;
@@ -41,7 +44,7 @@ secureExpressApp(app);
 // Add express route
 app.put(
   "/adm/services/:serviceid/logo",
-  UploadServiceLogo(serviceModel, logosUrl)
+  UploadServiceLogo(serviceModel, blobService, logosUrl)
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/UploadServiceLogo/index.ts
+++ b/UploadServiceLogo/index.ts
@@ -28,7 +28,7 @@ const servicesContainer = database.container(SERVICE_COLLECTION_NAME);
 
 const serviceModel = new ServiceModel(servicesContainer);
 
-const blobService = createBlobService(config.StorageConnection);
+const blobService = createBlobService(config.AssetsStorageConnection);
 
 // tslint:disable-next-line: no-let
 let logger: Context["log"] | undefined;

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -114,6 +114,7 @@ export const IConfig = t.intersection([
     USER_DATA_BACKUP_CONTAINER_NAME: NonEmptyString,
     USER_DATA_CONTAINER_NAME: NonEmptyString,
 
+    AssetsStorageConnection: NonEmptyString,
     StorageConnection: NonEmptyString,
     SubscriptionFeedStorageConnection: NonEmptyString,
     UserDataArchiveStorageConnection: NonEmptyString,


### PR DESCRIPTION
This PR introduce lowercase transformation on blob name while uploading a service logo, due to wrong discovery by IO-APP that uses lowercase naming convention.
It also introduce the azure storage' sdk usage, because these kind of transformations (lowercase of the variables) are not allowed in azure bindings approach.

So changes can be resumed as follow:
* Out binding deletion (blob type) on `function.json`;
* Handler now use `blobService`, in order to write blob on `AssetsStorage` identified by `AssetsStorageConnection` config variable;
* Config module now handle `AssetsStorageConnection` that was missing;
* Tests refactoring due to implementation changes;