### PR TITLE
[#175497987] fix final status on abort

### DIFF
--- a/UserDataDeleteOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDeleteOrchestrator/__tests__/handler.test.ts
@@ -358,7 +358,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        nextStatus: UserDataProcessingStatusEnum.ABORTED
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
     );
     expect(setUserSessionLockActivity).not.toHaveBeenCalled();

--- a/UserDataDeleteOrchestrator/handler.ts
+++ b/UserDataDeleteOrchestrator/handler.ts
@@ -453,11 +453,11 @@ export const createUserDataDeleteOrchestratorHandler = (
           `${logPrefix}|VERBOSE|Operation resumed because of abort event`
         );
 
-        // set as aborted
+        // set as closed
         yield* setUserDataProcessingStatus(
           context,
           currentUserDataProcessing,
-          UserDataProcessingStatusEnum.ABORTED
+          UserDataProcessingStatusEnum.CLOSED
         );
 
         trackUserDataDeleteEvent("aborted", currentUserDataProcessing);


### PR DESCRIPTION
That was set to `ABORTED` by mistake. Please remind that this process is triggered by an incoming `ABORTED` record on the `user-data-processing` collection, so this bug used to lead to 2 `ABORTED` statuses in a row.

Anyway, that is not an issue at application level.
