### PR TITLE
[#175160851] Fix service model openapi

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -498,6 +498,14 @@ definitions:
     "$ref": "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/ServiceMetadata"
   ServiceScope:
     "$ref": "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/ServiceScope"
+  ServicePayload:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/ServicePayload"
+  HiddenServicePayload:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/HiddenServicePayload"
+  VisibleServicePayload:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/VisibleServicePayload"   
+  CommonServicePayload:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/CommonServicePayload"
   ServiceId:
     $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/master/openapi/definitions.yaml#/ServiceId"
   ServiceName:


### PR DESCRIPTION
Add ServicePayload, HiddenServicePayload, VisibleServicePayload and CommonServicePayload to openapi definition.

These changes are required due to the following known issue on `pagopa/io-utils`: https://github.com/pagopa/io-utils#a-model-file-for-a-definition-is-not-generated