### PR TITLE
[#IP-256] Added retry to SetUserDataProcessingStatusActivity calls

### DIFF
--- a/UserDataDeleteOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDeleteOrchestrator/__tests__/handler.test.ts
@@ -151,6 +151,8 @@ const context = (mockOrchestratorContext as unknown) as IOrchestrationFunctionCo
 const waitForAbortInterval = 0 as Day;
 const waitForDownloadInterval = 0 as Hour;
 
+const expectedRetryOptions = expect.any(Object);
+
 // eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("createUserDataDeleteOrchestratorHandler", () => {
   beforeEach(() => {
@@ -191,7 +193,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -214,7 +216,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -237,7 +239,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -269,7 +271,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -297,7 +299,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -318,14 +320,14 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.WIP
       })
     );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
@@ -364,7 +366,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
@@ -481,7 +483,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })

--- a/UserDataDeleteOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDeleteOrchestrator/__tests__/handler.test.ts
@@ -191,6 +191,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -213,6 +214,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -235,6 +237,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -266,6 +269,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -293,6 +297,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
@@ -313,12 +318,14 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.WIP
       })
     );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
@@ -357,6 +364,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
@@ -473,6 +481,7 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })

--- a/UserDataDownloadOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDownloadOrchestrator/__tests__/handler.test.ts
@@ -78,6 +78,8 @@ const consumeOrchestrator = (orch: any) => {
 // just a convenient cast, good for every test case
 const context = (mockOrchestratorContext as unknown) as IOrchestrationFunctionContext;
 
+const expectedRetryOptions = expect.any(Object);
+
 // eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("UserDataDownloadOrchestrator", () => {
   beforeEach(() => {
@@ -129,7 +131,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // first, set as WIP
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.WIP
@@ -138,7 +140,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as CLOSED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.CLOSED
@@ -165,7 +167,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as FAILED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -195,7 +197,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as FAILED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -231,7 +233,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // the last call to SetUserDataProcessingStatusActivity should be set as FAILED with a reason
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -273,7 +275,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // the last call to SetUserDataProcessingStatusActivity should be set as FAILED with a reason
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,

--- a/UserDataDownloadOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDownloadOrchestrator/__tests__/handler.test.ts
@@ -19,9 +19,6 @@ import {
 } from "../handler";
 
 import { ActivityResultSuccess as SetUserDataProcessingStatusActivityResultSuccess } from "../../SetUserDataProcessingStatusActivity/handler";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { ExponentialRetryPolicyFilter } from "azure-storage";
-import { UserDataProcessing } from "@pagopa/io-functions-commons/dist/src/models/user_data_processing";
 
 const aNonSuccess = "any non-success value";
 
@@ -132,6 +129,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // first, set as WIP
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.WIP
@@ -140,6 +138,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as CLOSED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.CLOSED
@@ -166,6 +165,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as FAILED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -195,6 +195,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // then, set as FAILED
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -230,6 +231,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // the last call to SetUserDataProcessingStatusActivity should be set as FAILED with a reason
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,
@@ -271,6 +273,7 @@ describe("UserDataDownloadOrchestrator", () => {
     // the last call to SetUserDataProcessingStatusActivity should be set as FAILED with a reason
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
+      expect.any(Object),
       {
         currentRecord: expect.any(Object),
         nextStatus: UserDataProcessingStatusEnum.FAILED,

--- a/UserDataProcessingRecoveryOrchestrator/__tests__/handler.test.ts
+++ b/UserDataProcessingRecoveryOrchestrator/__tests__/handler.test.ts
@@ -5,19 +5,15 @@ import {
   mockOrchestratorGetInput
 } from "../../__mocks__/durable-functions";
 import {
-  ActivityInput as CheckLastStatusActivityInput,
   ActivityResultSuccess as CheckLastStatusActivityResultSuccess
 } from "../../UserDataProcessingCheckLastStatusActivity/handler";
 import {
-  ActivityInput as FindFailureReasonActivityInput,
   ActivityResultSuccess as FindFailureReasonActivityResultSuccess
 } from "../../UserDataProcessingFindFailureReasonActivity/handler";
 import {
-  ActivityInput as SetUserDataProcessingStatusActivityInput,
   ActivityResultSuccess as SetUserDataProcessingStatusActivityResultSuccess
 } from "../../SetUserDataProcessingStatusActivity/handler";
 import {
-  ActivityFailure,
   handler,
   InvalidInputFailure,
   OrchestratorFailure,
@@ -295,6 +291,7 @@ describe("UserDataProcessingRecoveryOrchestrator", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       "SetUserDataProcessingStatusActivity",
+      expect.any(Object),
       {
         currentRecord: aFailedUserDataProcessing,
         failureReason: "Any found reason",

--- a/UserDataProcessingRecoveryOrchestrator/__tests__/handler.test.ts
+++ b/UserDataProcessingRecoveryOrchestrator/__tests__/handler.test.ts
@@ -277,6 +277,8 @@ describe("UserDataProcessingRecoveryOrchestrator", () => {
       }
     );
 
+    const expectedRetryOptions = expect.any(Object);
+
     expect(findFailureReasonActivity).toHaveBeenCalled();
     expect(findFailureReasonActivity).toHaveBeenCalledTimes(1);
     expect(findFailureReasonActivity).toHaveBeenCalledWith(
@@ -291,7 +293,7 @@ describe("UserDataProcessingRecoveryOrchestrator", () => {
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       "SetUserDataProcessingStatusActivity",
-      expect.any(Object),
+      expectedRetryOptions,
       {
         currentRecord: aFailedUserDataProcessing,
         failureReason: "Any found reason",


### PR DESCRIPTION
#### List of Changes
- Added retry to SetUserDataProcessingStatusActivity calls
- updated tests to consider retryOptions as parameter

#### Motivation and Context
We want to retry the operation if we fail to set a user_data_processing status.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
