### PR TITLE
[#IP-154] UserDataProcessingDeleteOrchestrator can manage previous failed requests if they are resumed

### DIFF
--- a/GetUserDataProcessingActivity/__tests__/handler.test.ts
+++ b/GetUserDataProcessingActivity/__tests__/handler.test.ts
@@ -21,7 +21,7 @@ import { toCosmosErrorResponse } from "@pagopa/io-functions-commons/dist/src/uti
 
 const aChoice = aUserDataProcessing.choice;
 
-describe("SetUserDataProcessingStatusActivityHandler", () => {
+describe("GetUserDataProcessingActivityHandler", () => {
   it("should handle a result", async () => {
     const mockModel = ({
       findLastVersionByModelId: jest.fn(() =>

--- a/IsFailedUserDataProcessingActivity/__tests__/handler.test.ts
+++ b/IsFailedUserDataProcessingActivity/__tests__/handler.test.ts
@@ -1,0 +1,199 @@
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { TableService } from "azure-storage";
+import {
+  UserDataProcessingChoice,
+  UserDataProcessingChoiceEnum
+} from "@pagopa/io-functions-commons/dist/generated/definitions/UserDataProcessingChoice";
+import {
+  ActivityResultFailure,
+  ActivityResultSuccess,
+  IsFailedUserDataProcessing
+} from "../handler";
+
+const findEntry = (
+  entries: ReadonlyArray<{
+    PartitionKey: UserDataProcessingChoice;
+    RowKey: FiscalCode;
+  }>
+) => (choice, fiscalCode) =>
+  entries.length > 0
+    ? entries
+        .filter(e => e.PartitionKey === choice && e.RowKey === fiscalCode)
+        .map(e => ({
+          RowKey: { _: e.RowKey }
+        }))[0]
+    : null;
+
+const retrieveEntityFailedUserDataProcessingMock = (
+  entries: ReadonlyArray<{
+    PartitionKey: UserDataProcessingChoice;
+    RowKey: FiscalCode;
+  }>
+) =>
+  jest.fn((_, choice, fiscalCode, ____, cb) => {
+    return cb(
+      findEntry(entries)(choice, fiscalCode)
+        ? null
+        : new Error("Internal error"),
+      findEntry(entries)(choice, fiscalCode),
+      {
+        isSuccessful: findEntry(entries)(choice, fiscalCode),
+        statusCode: findEntry(entries)(choice, fiscalCode) ? 200 : 404
+      }
+    );
+  });
+
+const internalErrorRetrieveEntityFailedUserDataProcessingMock = (
+  entries: ReadonlyArray<{
+    PartitionKey: UserDataProcessingChoice;
+    RowKey: FiscalCode;
+  }>
+) =>
+  jest.fn((_, choice, fiscalCode, ____, cb) => {
+    return cb(new Error("Internal error"), null, { isSuccessful: false });
+  });
+
+const storageTableMock = "FailedUserDataProcessing" as NonEmptyString;
+
+const fiscalCode1 = "UEEFON48A55Y758X" as FiscalCode;
+const fiscalCode2 = "VEEGON48A55Y758Z" as FiscalCode;
+
+const noFailedRequests = [];
+
+const failedRequests = [
+  {
+    PartitionKey: UserDataProcessingChoiceEnum.DELETE,
+    RowKey: fiscalCode1
+  },
+  {
+    PartitionKey: UserDataProcessingChoiceEnum.DOWNLOAD,
+    RowKey: fiscalCode1
+  },
+  {
+    PartitionKey: UserDataProcessingChoiceEnum.DELETE,
+    RowKey: fiscalCode2
+  },
+  {
+    PartitionKey: UserDataProcessingChoiceEnum.DOWNLOAD,
+    RowKey: fiscalCode2
+  }
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("IsFailedUserDataProcessingHandler", () => {
+  it("should fail if input is not valid", async () => {
+    const tableServiceMock = ({
+      retrieveEntity: retrieveEntityFailedUserDataProcessingMock(
+        noFailedRequests
+      )
+    } as any) as TableService;
+
+    const getFailedUserDataProcessingHandler = IsFailedUserDataProcessing(
+      tableServiceMock,
+      storageTableMock
+    );
+
+    const result = await getFailedUserDataProcessingHandler({} as any, {
+      a: "a",
+      b: "b",
+      c: "c"
+    });
+
+    expect(ActivityResultFailure.is(result)).toBe(true);
+    const decodedResult = ActivityResultFailure.decode(result);
+    expect(decodedResult.isRight()).toBe(true);
+    if (decodedResult.isRight()) {
+      expect(JSON.stringify(decodedResult.value)).toBe(
+        JSON.stringify({
+          kind: "FAILURE",
+          reason: "Invalid input"
+        })
+      );
+    }
+  });
+
+  it("should fail if any error occurs", async () => {
+    const tableServiceMock = ({
+      retrieveEntity: internalErrorRetrieveEntityFailedUserDataProcessingMock(
+        failedRequests
+      )
+    } as any) as TableService;
+
+    const getFailedUserDataProcessingHandler = IsFailedUserDataProcessing(
+      tableServiceMock,
+      storageTableMock
+    );
+
+    const result = await getFailedUserDataProcessingHandler({} as any, {
+      choice: UserDataProcessingChoiceEnum.DELETE,
+      fiscalCode: fiscalCode1
+    });
+
+    expect(ActivityResultFailure.is(result)).toBe(true);
+    const decodedResult = ActivityResultFailure.decode(result);
+    expect(decodedResult.isRight()).toBe(true);
+    if (decodedResult.isRight()) {
+      expect(JSON.stringify(decodedResult.value)).toBe(
+        JSON.stringify({
+          kind: "FAILURE",
+          reason: "ERROR|tableService.retrieveEntity|Cannot retrieve entity"
+        })
+      );
+    }
+  });
+
+  it("should succeed with false value if no failed user data processing is present", async () => {
+    const tableServiceMock = ({
+      retrieveEntity: retrieveEntityFailedUserDataProcessingMock(
+        noFailedRequests
+      )
+    } as any) as TableService;
+
+    const getFailedUserDataProcessingHandler = IsFailedUserDataProcessing(
+      tableServiceMock,
+      storageTableMock
+    );
+
+    const result = await getFailedUserDataProcessingHandler({} as any, {
+      choice: UserDataProcessingChoiceEnum.DELETE,
+      fiscalCode: fiscalCode1
+    });
+
+    expect(ActivityResultSuccess.is(result)).toBe(true);
+    const decodedResult = ActivityResultSuccess.decode(result);
+    expect(decodedResult.isRight()).toBe(true);
+    if (decodedResult.isRight()) {
+      expect(JSON.stringify(decodedResult.value)).toBe(
+        JSON.stringify({ kind: "SUCCESS", value: false })
+      );
+    }
+  });
+
+  it("should succeed with true value if failed user data processing is present", async () => {
+    const tableServiceMock = ({
+      retrieveEntity: retrieveEntityFailedUserDataProcessingMock(failedRequests)
+    } as any) as TableService;
+
+    const getFailedUserDataProcessingHandler = IsFailedUserDataProcessing(
+      tableServiceMock,
+      storageTableMock
+    );
+
+    const result = await getFailedUserDataProcessingHandler({} as any, {
+      choice: UserDataProcessingChoiceEnum.DELETE,
+      fiscalCode: fiscalCode1
+    });
+
+    expect(ActivityResultSuccess.is(result)).toBe(true);
+    const decodedResult = ActivityResultSuccess.decode(result);
+    expect(decodedResult.isRight()).toBe(true);
+    if (decodedResult.isRight()) {
+      expect(JSON.stringify(decodedResult.value)).toBe(
+        JSON.stringify({ kind: "SUCCESS", value: true })
+      );
+    }
+  });
+});

--- a/IsFailedUserDataProcessingActivity/function.json
+++ b/IsFailedUserDataProcessingActivity/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/IsFailedUserDataProcessingActivity/index.js"
+}

--- a/IsFailedUserDataProcessingActivity/handler.ts
+++ b/IsFailedUserDataProcessingActivity/handler.ts
@@ -1,0 +1,96 @@
+import { Context } from "@azure/functions";
+import { ServiceResponse, TableService } from "azure-storage";
+import { fromOption } from "fp-ts/lib/Either";
+import { NonEmptyString, FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { UserDataProcessingChoice } from "@pagopa/io-functions-commons/dist/generated/definitions/UserDataProcessingChoice";
+import { fromEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { none, Option, some } from "fp-ts/lib/Option";
+import * as t from "io-ts";
+import { identity } from "fp-ts/lib/function";
+
+// Activity input
+export const ActivityInput = t.interface({
+  choice: UserDataProcessingChoice,
+  fiscalCode: FiscalCode
+});
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+// Activity result
+export type ActivityResultSuccess = t.TypeOf<typeof ActivityResultSuccess>;
+export const ActivityResultSuccess = t.interface({
+  kind: t.literal("SUCCESS"),
+  value: t.boolean
+});
+
+export type ActivityResultFailure = t.TypeOf<typeof ActivityResultFailure>;
+export const ActivityResultFailure = t.interface({
+  kind: t.literal("FAILURE"),
+  reason: t.string
+});
+
+export const ActivityResult = t.taggedUnion("kind", [
+  ActivityResultSuccess,
+  ActivityResultFailure
+]);
+export type ActivityResult = t.TypeOf<typeof ActivityResult>;
+
+// Table storage result
+type TableEntry = Readonly<{
+  readonly RowKey: Readonly<{
+    readonly _: FiscalCode;
+  }>;
+}>;
+
+export const IsFailedUserDataProcessing = (
+  tableService: TableService,
+  failedUserDataProcessingTable: NonEmptyString
+) => (context: Context, input: unknown): Promise<ActivityResult> =>
+  fromEither(ActivityInput.decode(input))
+    .mapLeft<ActivityResult>(_ =>
+      ActivityResultFailure.encode({
+        kind: "FAILURE",
+        reason: "Invalid input"
+      })
+    )
+    .chain(i =>
+      tryCatch(
+        () =>
+          new Promise<Option<TableEntry>>((resolve, reject) =>
+            tableService.retrieveEntity(
+              failedUserDataProcessingTable,
+              i.choice,
+              i.fiscalCode,
+              null,
+              (error: Error, result: TableEntry, response: ServiceResponse) =>
+                response.isSuccessful
+                  ? resolve(some(result))
+                  : response.statusCode === 404
+                  ? resolve(none)
+                  : reject(error)
+            )
+          ),
+        _ =>
+          ActivityResultFailure.encode({
+            kind: "FAILURE",
+            reason: "ERROR|tableService.retrieveEntity|Cannot retrieve entity"
+          })
+      )
+    )
+    .chain(maybeTableEntry =>
+      fromEither(
+        fromOption(
+          ActivityResultSuccess.encode({
+            kind: "SUCCESS",
+            value: false
+          })
+        )(maybeTableEntry)
+      )
+    )
+    .map(_ =>
+      ActivityResultSuccess.encode({
+        kind: "SUCCESS",
+        value: true
+      })
+    )
+    .fold<ActivityResult>(identity, identity)
+    .run();

--- a/IsFailedUserDataProcessingActivity/index.ts
+++ b/IsFailedUserDataProcessingActivity/index.ts
@@ -1,0 +1,19 @@
+import { createTableService } from "azure-storage";
+import { getConfigOrThrow } from "../utils/config";
+import { IsFailedUserDataProcessing } from "./handler";
+
+/**
+ * Table service
+ */
+const config = getConfigOrThrow();
+const storageConnectionString =
+  config.FailedUserDataProcessingStorageConnection;
+const failedUserDataProcessingTable = config.FAILED_USER_DATA_PROCESSING_TABLE;
+const tableService = createTableService(storageConnectionString);
+
+const activityFunctionHandler = IsFailedUserDataProcessing(
+  tableService,
+  failedUserDataProcessingTable
+);
+
+export default activityFunctionHandler;

--- a/UserDataDeleteOrchestrator/__tests__/handler.test.ts
+++ b/UserDataDeleteOrchestrator/__tests__/handler.test.ts
@@ -1,5 +1,3 @@
-// eslint-disable @typescript-eslint/no-explicit-any
-
 import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
 import {
   mockOrchestratorCallActivity,
@@ -29,12 +27,20 @@ import {
   ActivityResultNotFoundFailure as GetUserDataProcessingActivityResultNotFoundFailure,
   ActivityResultSuccess as GetUserDataProcessingActivityResultSuccess
 } from "../../GetUserDataProcessingActivity/handler";
+import {
+  ActivityInput as IsFailedUserDataProcessingActivityInput,
+  ActivityResultSuccess as IsFailedUserDataProcessingActivityResultSuccess
+} from "../../IsFailedUserDataProcessingActivity/handler";
 import { ActivityResultSuccess as SetUserDataProcessingStatusActivityResultSuccess } from "../../SetUserDataProcessingStatusActivity/handler";
 import { ActivityResultSuccess as SetUserSessionLockActivityResultSuccess } from "../../SetUserSessionLockActivity/handler";
 import { OrchestratorFailure } from "../../UserDataDownloadOrchestrator/handler";
-import { ActivityResultSuccess as GetProfileActivityResultSuccess } from "../../GetProfileActivity/handler";
+import {
+  ActivityResultSuccess as GetProfileActivityResultSuccess,
+  ActivityResultNotFoundFailure as GetProfileActivityResultNotFoundFailure
+} from "../../GetProfileActivity/handler";
 import { ProcessableUserDataDelete } from "../../UserDataProcessingTrigger/handler";
 import { ActivityResultSuccess as SendUserDataDeleteEmailActivityResultSuccess } from "../../SendUserDataDeleteEmailActivity/handler";
+import { addDays, addHours } from "../utils";
 
 const aProcessableUserDataDelete = ProcessableUserDataDelete.decode({
   ...aUserDataProcessing,
@@ -61,6 +67,15 @@ const aUserDataDownloadClosed = {
   choice: UserDataProcessingChoiceEnum.DOWNLOAD,
   status: UserDataProcessingStatusEnum.CLOSED
 };
+
+// this mock will default to a not failed request to be transparent for old tests
+// we will override this just to test new logic for failed requests
+const isFailedUserDataProcessingActivity = jest.fn().mockImplementation(() =>
+  IsFailedUserDataProcessingActivityResultSuccess.encode({
+    kind: "SUCCESS",
+    value: false
+  })
+);
 
 const setUserDataProcessingStatusActivity = jest.fn().mockImplementation(() =>
   SetUserDataProcessingStatusActivityResultSuccess.encode({
@@ -117,6 +132,8 @@ const switchMockImplementation = (name: string, ...args: readonly unknown[]) =>
     ? getProfileActivity
     : name === "UpdateSubscriptionsFeedActivity"
     ? updateSubscriptionFeed
+    : name === "IsFailedUserDataProcessingActivity"
+    ? isFailedUserDataProcessingActivity
     : jest.fn())(name, ...args);
 
 // I assign switchMockImplementation to both because
@@ -134,7 +151,6 @@ mockOrchestratorCallActivityWithRetry.mockImplementation(
  * @returns the last value yielded by the orchestrator
  */
 const consumeOrchestrator = (orch: any) => {
-  // eslint-disable-next-line functional/no-let
   let prevValue: unknown;
   while (true) {
     const { done, value } = orch.next(prevValue);
@@ -148,18 +164,19 @@ const consumeOrchestrator = (orch: any) => {
 // just a convenient cast, good for every test case
 const context = (mockOrchestratorContext as unknown) as IOrchestrationFunctionContext;
 
-const waitForAbortInterval = 0 as Day;
-const waitForDownloadInterval = 0 as Hour;
+// timer are not delayed for test, but we set default values
+// to test any override, i.e. the grace period for failed requests
+const waitForAbortInterval = 1 as Day;
+const waitForDownloadInterval = 1 as Hour;
 
 const expectedRetryOptions = expect.any(Object);
 
-// eslint-disable-next-line sonar/sonar-max-lines-per-function
 describe("createUserDataDeleteOrchestratorHandler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should fail on invalid input", () => {
+  it("all requests: should fail on invalid input", () => {
     mockOrchestratorGetInput.mockReturnValueOnce("invalid input");
 
     const result = consumeOrchestrator(
@@ -171,15 +188,80 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
 
     expect(InvalidInputFailure.decode(result).isRight()).toBe(true);
 
-    expect(setUserDataProcessingStatusActivity).not.toHaveBeenCalled();
-    expect(deleteUserDataActivity).not.toHaveBeenCalled();
+    expect(getProfileActivity).not.toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(context.df.createTimer).not.toHaveBeenCalled();
+
     expect(setUserSessionLockActivity).not.toHaveBeenCalled();
+
+    expect(setUserDataProcessingStatusActivity).not.toHaveBeenCalled();
+
+    expect(getUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).not.toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
   });
 
-  it("should set processing ad FAILED if fails to lock the user session", () => {
+  it("all requests: should set status as FAILED if user profile does not exist", () => {
+    mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
+    getProfileActivity.mockImplementationOnce(() =>
+      GetProfileActivityResultNotFoundFailure.encode({
+        kind: "NOT_FOUND_FAILURE"
+      })
+    );
+
+    const result = consumeOrchestrator(
+      createUserDataDeleteOrchestratorHandler(
+        waitForAbortInterval,
+        waitForDownloadInterval
+      )(context)
+    );
+
+    expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+    expect(getProfileActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      })
+    );
+
+    expect(isFailedUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(context.df.createTimer).not.toHaveBeenCalled();
+
+    expect(setUserSessionLockActivity).not.toHaveBeenCalled();
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.FAILED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).not.toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
+  });
+
+  it("new processing requests: should set status as FAILED if fails to lock the user session", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
     setUserSessionLockActivity.mockImplementationOnce(
-      // eslint-disable-next-line sonarjs/no-duplicate-string
       () => "any unsuccessful value"
     );
 
@@ -191,6 +273,31 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(1);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    // if session lock fails WIP status is never set, we just put it in FAILED
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
@@ -198,10 +305,19 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
     );
+
+    expect(getUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).not.toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
   });
 
-  it("should set processing ad FAILED if fails to set the operation as WIP", () => {
+  it("new processing requests: should set status as FAILED if fails to set the operation as WIP", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     setUserDataProcessingStatusActivity.mockImplementationOnce(
       () => "any unsuccessful value"
     );
@@ -214,6 +330,37 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(1);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
@@ -221,10 +368,19 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
     );
+
+    expect(getUserDataProcessingActivity).not.toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).not.toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
   });
 
-  it("should set processing ad FAILED if fails delete user data", () => {
+  it("new processing requests: should set status as FAILED if fails delete user data", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     deleteUserDataActivity.mockImplementationOnce(
       () => "any unsuccessful value"
     );
@@ -237,6 +393,37 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(1);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
@@ -244,15 +431,26 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
     );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
   });
 
-  it("should set processing ad FAILED if fails to unlock the user session", () => {
+  it("new processing requests: should set status as FAILED if fails to unlock the user session", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     setUserSessionLockActivity.mockImplementationOnce(() =>
       SetUserSessionLockActivityResultSuccess.encode({
         kind: "SUCCESS"
       })
     );
+
     setUserSessionLockActivity.mockImplementationOnce(
       () => "any unsuccessful value"
     );
@@ -265,10 +463,51 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
-    // data has been deletes
-    expect(deleteUserDataActivity).toHaveBeenCalled();
-    // the email has been sent
-    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+
+    expect(getProfileActivity).toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(3);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
@@ -276,15 +515,36 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
     );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+
+    // data has been deletes
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+
+    // the email has been sent
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledTimes(1);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.FAILED
+      })
+    );
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
 
-  it("should set processing ad FAILED if fails to set the operation as WIP", () => {
+  it("new processing requests: should set status as FAILED if fails to set the operation as CLOSED", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     setUserDataProcessingStatusActivity.mockImplementationOnce(() =>
       SetUserDataProcessingStatusActivityResultSuccess.encode({
         kind: "SUCCESS"
       })
     );
+
     setUserDataProcessingStatusActivity.mockImplementationOnce(
       () => "any unsuccessful value"
     );
@@ -297,6 +557,44 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(1);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(3);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
@@ -304,9 +602,17 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.FAILED
       })
     );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
   });
 
-  it("should set status as CLOSED if wait interval expires", () => {
+  it("new processing requests: should delete profile, send email and set status as CLOSED if wait interval expires", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
 
     const result = consumeOrchestrator(
@@ -317,6 +623,35 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
@@ -332,23 +667,21 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
     );
-    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
-    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        action: "LOCK"
-      })
-    );
-    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        action: "UNLOCK"
-      })
-    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+    expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
     expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledTimes(1);
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
 
-  it("should set status as CLOSED if abort request comes before wait interval expires", () => {
+  it("new processing requests: should not delete profile and set status as CLOSED if abort request comes before wait interval expires", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
 
     // I trick the implementation of Task.any to return the second event, not the first
@@ -362,7 +695,26 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
     expect(mockOrchestratorCancelTimer).toHaveBeenCalledTimes(1);
+
+    expect(setUserSessionLockActivity).not.toHaveBeenCalled();
+
+    // if abort event is sent no WIP status is set, only CLOSED
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(1);
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
@@ -371,11 +723,17 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
     );
-    expect(setUserSessionLockActivity).not.toHaveBeenCalled();
+
+    expect(getUserDataProcessingActivity).not.toHaveBeenCalled();
+
     expect(deleteUserDataActivity).not.toHaveBeenCalled();
+
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).not.toHaveBeenCalled();
   });
 
-  it("should wait if there are pending downloads", () => {
+  it("new processing requests: should wait if there are pending downloads, then delete profile, send email and set status as CLOSED", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
 
     // call 1: it's pending
@@ -410,19 +768,139 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test timers
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(3);
+    // test that grace period is respected for abort
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+    // test that we wait for pending download
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addHours(context.df.currentUtcDateTime, waitForDownloadInterval)
+    );
+    // test that we wait for wip download
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addHours(context.df.currentUtcDateTime, waitForDownloadInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
     expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(3);
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledTimes(1);
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
 
-  it("should send a confirmation email if the operation succeeded", () => {
+  it("new processing requests: should send a confirmation email if the operation succeeded", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     const result = consumeOrchestrator(
       createUserDataDeleteOrchestratorHandler(
         waitForAbortInterval,
         waitForDownloadInterval
       )(context)
     );
+
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+    expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
     expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledTimes(1);
     expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -430,16 +908,21 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
         fiscalCode: aProcessableUserDataDelete.fiscalCode
       })
     );
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
 
-  it("should not send a confirmation email if the email is not present", () => {
+  it("new processing requests: should not send a confirmation email if the email is not present", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     getProfileActivity.mockImplementationOnce(() =>
       GetProfileActivityResultSuccess.encode({
         kind: "SUCCESS",
         value: { ...aRetrievedProfile, email: undefined }
       })
     );
+
     const result = consumeOrchestrator(
       createUserDataDeleteOrchestratorHandler(
         waitForAbortInterval,
@@ -448,18 +931,74 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+    expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
     expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
     expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
 
-  it("should not send a confirmation email if the email is not enabled", () => {
+  it("new processing requests: should not send a confirmation email if the email is not enabled", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     getProfileActivity.mockImplementationOnce(() =>
       GetProfileActivityResultSuccess.encode({
         kind: "SUCCESS",
         value: { ...aRetrievedProfile, isEmailEnabled: false }
       })
     );
+
     const result = consumeOrchestrator(
       createUserDataDeleteOrchestratorHandler(
         waitForAbortInterval,
@@ -468,24 +1007,206 @@ describe("createUserDataDeleteOrchestratorHandler", () => {
     );
 
     expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+    expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
     expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
     expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
   });
-  it("should set processing ad FAILED if subscription feed fails to update", () => {
+
+  it("new processing requests: should set status as FAILED if subscription feed fails to update", () => {
     mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
     updateSubscriptionFeed.mockImplementationOnce(() => "FAILURE");
+
     const result = consumeOrchestrator(
       createUserDataDeleteOrchestratorHandler(
         waitForAbortInterval,
         waitForDownloadInterval
       )(context)
     );
+
     expect(OrchestratorFailure.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    // test that grace period is respected
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+    );
+
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(1);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
     expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
       expect.any(String),
       expectedRetryOptions,
       expect.objectContaining({
         nextStatus: UserDataProcessingStatusEnum.FAILED
+      })
+    );
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+    expect(getUserDataProcessingActivity).toHaveBeenCalledTimes(1);
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+    expect(deleteUserDataActivity).toHaveBeenCalledTimes(1);
+
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalled();
+    expect(sendUserDataDeleteEmailActivity).toHaveBeenCalledTimes(1);
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+    expect(updateSubscriptionFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("failed processing requests: should set status as CLOSED without sending email and with a 0 grace period", () => {
+    mockOrchestratorGetInput.mockReturnValueOnce(aProcessableUserDataDelete);
+
+    isFailedUserDataProcessingActivity.mockImplementationOnce(() =>
+      IsFailedUserDataProcessingActivityResultSuccess.encode({
+        kind: "SUCCESS",
+        value: true
+      })
+    );
+
+    const result = consumeOrchestrator(
+      createUserDataDeleteOrchestratorHandler(
+        waitForAbortInterval,
+        waitForDownloadInterval
+      )(context)
+    );
+
+    expect(OrchestratorSuccess.decode(result).isRight()).toBe(true);
+
+    expect(getProfileActivity).toHaveBeenCalled();
+    expect(getProfileActivity).toHaveBeenCalledTimes(1);
+    expect(getProfileActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      })
+    );
+
+    expect(isFailedUserDataProcessingActivity).toHaveBeenCalled();
+
+    // test that no grace period has been given
+    expect(context.df.createTimer).toHaveBeenCalled();
+    expect(context.df.createTimer).toHaveBeenCalledTimes(1);
+    expect(context.df.createTimer).toHaveBeenCalledWith(
+      addDays(context.df.currentUtcDateTime, 0 as Day)
+    ); // this works because mocked context has the same currentUtcDateTime
+
+    expect(getUserDataProcessingActivity).toHaveBeenCalled();
+
+    expect(setUserSessionLockActivity).toHaveBeenCalled();
+    expect(setUserSessionLockActivity).toHaveBeenCalledTimes(2);
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "LOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+    expect(setUserSessionLockActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "UNLOCK",
+        fiscalCode: aProcessableUserDataDelete.fiscalCode
+      }
+    );
+
+    expect(deleteUserDataActivity).toHaveBeenCalled();
+
+    // test that no email has been sent
+    expect(sendUserDataDeleteEmailActivity).not.toHaveBeenCalled();
+
+    expect(updateSubscriptionFeed).toHaveBeenCalled();
+
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalled();
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledTimes(2);
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.WIP
+      })
+    );
+    expect(setUserDataProcessingStatusActivity).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedRetryOptions,
+      expect.objectContaining({
+        nextStatus: UserDataProcessingStatusEnum.CLOSED
       })
     );
   });

--- a/UserDataDeleteOrchestrator/handler.ts
+++ b/UserDataDeleteOrchestrator/handler.ts
@@ -396,6 +396,10 @@ export const createUserDataDeleteOrchestratorHandler = (
         currentUserDataProcessing
       );
 
+      context.log.verbose(
+        `${logPrefix}|VERBOSE|isFailedUserDataProcessingRequest=${isFailedUserDataProcessingRequest}`
+      );
+
       // we calculate the grace period: if this is a failed request => 0 days
       const gracePeriod = isFailedUserDataProcessingRequest
         ? (0 as Day)

--- a/UserDataDeleteOrchestrator/handler.ts
+++ b/UserDataDeleteOrchestrator/handler.ts
@@ -39,6 +39,11 @@ import {
   ActivityResultSuccess as SetUserSessionLockActivityResultSuccess
 } from "../SetUserSessionLockActivity/handler";
 
+import {
+  ActivityInput as IsFailedUserDataProcessingActivityInput,
+  ActivityResultSuccess as IsFailedUserDataProcessingActivityResultSuccess
+} from "../IsFailedUserDataProcessingActivity/handler";
+
 import { ActivityInput as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/types";
 import { ProcessableUserDataDelete } from "../UserDataProcessingTrigger/handler";
 import {
@@ -144,6 +149,28 @@ function* setUserSessionLock(
       );
     }
   );
+}
+
+function* isFailedUserDataProcessing(
+  context: IOrchestrationFunctionContext,
+  currentRecord: UserDataProcessing
+): Generator<Task, boolean> {
+  const result = yield context.df.callActivityWithRetry(
+    "IsFailedUserDataProcessingActivity",
+    retryOptions,
+    IsFailedUserDataProcessingActivityInput.encode({
+      choice: currentRecord.choice,
+      fiscalCode: currentRecord.fiscalCode
+    })
+  );
+  return IsFailedUserDataProcessingActivityResultSuccess.decode(
+    result
+  ).getOrElseL(_ => {
+    throw toActivityFailure(
+      { kind: "IS_FAILED_USER_DATA_PROCESSING_ACTIVITY_RESULT" },
+      "IsFailedUserDataProcessingActivity"
+    );
+  }).value;
 }
 
 function* setUserDataProcessingStatus(
@@ -324,6 +351,7 @@ export const createUserDataDeleteOrchestratorHandler = (
   waitForAbortInterval: Day,
   waitForDownloadInterval: Hour = 12 as Hour
 ) =>
+  // eslint-disable-next-line max-lines-per-function
   function*(context: IOrchestrationFunctionContext): Generator<Task | TaskSet> {
     const document = context.df.getInput();
     // This check has been done on the trigger, so it should never fail.
@@ -355,16 +383,34 @@ export const createUserDataDeleteOrchestratorHandler = (
     );
 
     try {
+      // retrieve user profile
+      const profile = yield* getProfile(
+        context,
+        currentUserDataProcessing.fiscalCode
+      );
+
+      // if profile exists, we check if this is a failed processing request because failed requests
+      // are managed without waiting any abort event and without sending any email
+      const isFailedUserDataProcessingRequest = yield* isFailedUserDataProcessing(
+        context,
+        currentUserDataProcessing
+      );
+
+      // we calculate the grace period: if this is a failed request => 0 days
+      const gracePeriod = isFailedUserDataProcessingRequest
+        ? (0 as Day)
+        : waitForAbortInterval;
+
       // we have an interval on which we wait for eventual cancellation by the user
       const intervalExpiredEvent = context.df.createTimer(
-        addDays(context.df.currentUtcDateTime, waitForAbortInterval)
+        addDays(context.df.currentUtcDateTime, gracePeriod)
       );
 
       // we wait for eventually abort message from the user
       const canceledRequestEvent = context.df.waitForExternalEvent(ABORT_EVENT);
 
       context.log.verbose(
-        `${logPrefix}|VERBOSE|Operation stopped for ${waitForAbortInterval} days`
+        `${logPrefix}|VERBOSE|Operation stopped for ${gracePeriod} days`
       );
 
       trackUserDataDeleteEvent("paused", currentUserDataProcessing);
@@ -377,7 +423,7 @@ export const createUserDataDeleteOrchestratorHandler = (
 
       if (triggeredEvent === intervalExpiredEvent) {
         context.log.verbose(
-          `${logPrefix}|VERBOSE|Operation resumed after ${waitForAbortInterval} days`
+          `${logPrefix}|VERBOSE|Operation resumed after ${gracePeriod} days`
         );
 
         // lock user session
@@ -411,12 +457,6 @@ export const createUserDataDeleteOrchestratorHandler = (
           yield waitForDownloadEvent;
         }
 
-        // retrieve user profile
-        const profile = yield* getProfile(
-          context,
-          currentUserDataProcessing.fiscalCode
-        );
-
         // eslint-disable-next-line extra-rules/no-commented-out-code
         // backup&delete data
         yield* deleteUserData(context, currentUserDataProcessing);
@@ -425,7 +465,8 @@ export const createUserDataDeleteOrchestratorHandler = (
         if (
           profile.email &&
           profile.isEmailValidated &&
-          profile.isEmailEnabled
+          profile.isEmailEnabled &&
+          !isFailedUserDataProcessingRequest
         ) {
           // send confirm email
           yield* sendUserDataDeleteEmail(

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -75,9 +75,9 @@ export const mockCallSubOrchestrator = jest
   }));
 export const mockOrchestratorSetCustomStatus = jest.fn();
 export const mockOrchestratorCancelTimer = jest.fn();
-export const mockOrchestratorCreateTimer = () => ({
+export const mockOrchestratorCreateTimer = jest.fn().mockImplementation(() => ({
   cancel: mockOrchestratorCancelTimer
-});
+}));
 export const mockWaitForExternalEvent = jest
   .fn()
   .mockReturnValue("mockWaitForExternalEvent");


### PR DESCRIPTION
#### List of Changes
- Added activity to check if a request has previously failed
- Added a spy on context mock
- Changed the logic of UserDataProcessingDeleteOrchestrator
- Added more tests

#### Motivation and Context
We want to run a recovery on FAILED delete requests by setting them to PENDING again and letting the orchestrator do the job. 
There are 3 points to respect:
- No grace period is waited for failed requests
- No email is sent for failed requests
- Everything must work as expected for new request

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test
- tested on io-mock for the part regarding the new called activity to verify it's being called correctly

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
