### PR TITLE
Add uppercase and lowercase X to symbols

### DIFF
--- a/utils/random.ts
+++ b/utils/random.ts
@@ -9,7 +9,7 @@ import * as randomstring from "randomstring";
 
 /* printable 7 bit ASCII, some special char removed */
 const RANDOM_CHARSET =
-  "ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz0123456789!#$%&()*+-/=?@";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+-/=?@";
 
 export const StrongPassword = WithinRangeString(18, 19);
 export type StrongPassword = t.TypeOf<typeof StrongPassword>;


### PR DESCRIPTION
Quick fix adding `X` and `x` to the set of allowed symbols.