### PR TITLE
[#IC-356] Remove unused Orchestration Client

### DIFF
--- a/CreateService/function.json
+++ b/CreateService/function.json
@@ -14,11 +14,6 @@
       "type": "http",
       "direction": "out",
       "name": "res"
-    },
-    {
-      "type": "orchestrationClient",
-      "direction": "in",
-      "name": "starter"
     }
   ],
   "scriptFile": "../dist/CreateService/index.js"

--- a/UpdateService/function.json
+++ b/UpdateService/function.json
@@ -14,11 +14,6 @@
       "type": "http",
       "direction": "out",
       "name": "res"
-    },
-    {
-      "type": "orchestrationClient",
-      "direction": "in",
-      "name": "starter"
     }
   ],
   "scriptFile": "../dist/UpdateService/index.js"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Remove orchestration client from `CreateService` and `UpdateService`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The orchestration client in `CreateService` and `UpdateService` function is unused after pagopa/io-functions-admin#181

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not tested

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
