### PR TITLE
[#IOPSC-118] Respond with 'too many requests' status code when creating too much subscriptions for the same account

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -512,6 +512,8 @@ paths:
           description: Forbidden
         "404":
           description: Resource (User or Product) not found
+        "429":
+          description: Too Many Requests
         "500":
           description: Internal server error
 definitions:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@azure/arm-apimanagement": "^5.1.1",
     "@azure/cosmos": "^3.15.1",
     "@azure/graph": "^4.0.1",
-    "@azure/ms-rest-js": "^2.5.1",
+    "@azure/ms-rest-js": "^2.6.4",
     "@azure/ms-rest-nodeauth": "^2.0.6",
     "@pagopa/express-azure-functions": "^2.0.0",
     "@pagopa/io-functions-commons": "^25.5.2",

--- a/utils/__tests__/retry.test.ts
+++ b/utils/__tests__/retry.test.ts
@@ -1,0 +1,125 @@
+import { withRetry } from "../retry";
+
+const aGoodResult = 42;
+const aBadResult = "bad things happen here";
+const anAlwaysGoodOperation = jest.fn(() => Promise.resolve(aGoodResult));
+const anAlwaysBadOperation = jest.fn(() => Promise.reject(aBadResult));
+const anOperationGoodAtAttemptNth = (n: number) => {
+  let count = 0;
+  return jest.fn(() => {
+    count++;
+    if (count < n) {
+      return Promise.reject(aBadResult);
+    } else {
+      return Promise.resolve(aGoodResult);
+    }
+  });
+};
+
+const sleep = ms => new Promise(done => setTimeout(done, ms));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// check test helper
+describe("anOperationGoodAtAttemptNth", () => {
+  it("works as intended", () => {
+    const op = anOperationGoodAtAttemptNth(3);
+    const result1 = op();
+    const result2 = op();
+    const result3 = op();
+    const result4 = op();
+
+    expect(result1).rejects.toEqual(aBadResult);
+    expect(result2).rejects.toEqual(aBadResult);
+    expect(result3).resolves.toEqual(aGoodResult);
+    expect(result4).resolves.toEqual(aGoodResult);
+  });
+});
+
+describe("withRetry", () => {
+  it("should return a promise", async () => {
+    const retriable = withRetry()(anAlwaysGoodOperation);
+    const result = retriable();
+
+    // check is a Promise
+    expect(
+      result instanceof Object &&
+        "then" in result &&
+        typeof result.then === "function"
+    ).toBe(true);
+
+    const value = await result;
+    expect(value).toEqual(aGoodResult);
+    expect(anAlwaysGoodOperation).toBeCalledTimes(1);
+  });
+
+  it("should fail when the operations always fails", async () => {
+    const operation = anAlwaysBadOperation;
+    const retriable = withRetry()(operation);
+    const result = retriable();
+
+    try {
+      await result;
+      fail("expected to throw");
+    } catch (error) {
+      expect(error).toEqual(aBadResult);
+      expect(operation).toBeCalledTimes(3);
+    }
+  });
+
+  it("should fail when the operations fails more than retried times", async () => {
+    const operation = anOperationGoodAtAttemptNth(4);
+    const retriable = withRetry({ maxAttempts: 3 })(operation);
+    const result = retriable();
+
+    try {
+      await result;
+      fail("expected to throw");
+    } catch (error) {
+      expect(error).toEqual(aBadResult);
+      expect(operation).toBeCalledTimes(3);
+    }
+  });
+
+  it("should succeed when the operations fails less than retried times", async () => {
+    const operation = anOperationGoodAtAttemptNth(2);
+    const retriable = withRetry({ maxAttempts: 3 })(operation);
+    const result = retriable();
+
+    const value = await result;
+
+    expect(value).toEqual(aGoodResult);
+    expect(operation).toBeCalledTimes(2);
+  });
+
+  it("should not retry if whileCondition is not met", async () => {
+    const operation = anOperationGoodAtAttemptNth(2);
+    const retriable = withRetry({
+      maxAttempts: 3,
+      whileCondition: () => false
+    })(operation);
+    const result = retriable();
+
+    try {
+      await result;
+      fail("expected to throw");
+    } catch (error) {
+      expect(error).toEqual(aBadResult);
+      expect(operation).toBeCalledTimes(1);
+    }
+  });
+
+  it("should wait between invocations if a delay is provided", async () => {
+    const operation = anAlwaysBadOperation;
+    const waitFor = 1000;
+    const retriable = withRetry({ delayMS: waitFor })(operation);
+    const _ = retriable();
+
+    expect(operation).toBeCalledTimes(1);
+    await sleep(waitFor * 1.01);
+
+    expect(operation).toBeCalledTimes(2);
+  });
+});

--- a/utils/apim.ts
+++ b/utils/apim.ts
@@ -170,7 +170,14 @@ export const getSubscription = (
     ),
     chainApimMappedError
   );
-
+/**
+ * APIM sdk operations may raise untyped errors.
+ * This utility check if the error is of a specific status code
+ *
+ * @param error any error coming from an APIM sdk call
+ * @param statusCode status code to check against
+ * @returns whether the returned error is of that status code
+ */
 export const isErrorStatusCode = (
   error: unknown,
   statusCode: number

--- a/utils/apim.ts
+++ b/utils/apim.ts
@@ -18,6 +18,7 @@ import {
   ResponseErrorNotFound
 } from "@pagopa/ts-commons/lib/responses";
 import { parse } from "fp-ts/lib/Json";
+import { RestError } from "@azure/ms-rest-js";
 export interface IServicePrincipalCreds {
   readonly clientId: string;
   readonly secret: string;
@@ -169,3 +170,20 @@ export const getSubscription = (
     ),
     chainApimMappedError
   );
+
+export const isErrorStatusCode = (
+  error: unknown,
+  statusCode: number
+): boolean => {
+  if (error === null) {
+    return false;
+  }
+  if (!(error instanceof RestError)) {
+    return false;
+  }
+  if (!error.statusCode) {
+    return false;
+  }
+
+  return error.statusCode === statusCode;
+};

--- a/utils/retry.ts
+++ b/utils/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * Given an async operation, it retries the operation until
+ * the retry conditions are met and maximum attempts are fulfilled.
+ *
+ * An optional delay in milliseconds can be waited between attempts.
+ *
+ * @param operation the operation to be executed
+ * @param whileCondition stop retries when false. Default: alway true
+ * @param maxAttempts max total calls to operation. Default: 3
+ * @param delayMS delay between invocations. Default: 100ms
+ * @returns
+ */
+
+export const withRetry = ({
+  whileCondition = (_: unknown): true => true,
+  maxAttempts = 3,
+  delayMS = 100
+}: {
+  readonly whileCondition?: (failure: unknown) => boolean;
+  readonly maxAttempts?: number;
+  readonly delayMS?: number;
+} = {}) => <T>(operation: () => Promise<T>) => async (): Promise<T> => {
+  // eslint-disable-next-line functional/no-let
+  let remainingAttempts = maxAttempts;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      remainingAttempts--;
+
+      if (!remainingAttempts || !whileCondition(error)) {
+        throw error;
+      }
+
+      if (delayMS) {
+        await new Promise(done => setTimeout(done, delayMS));
+      }
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,7 +230,7 @@
     uuid "^3.2.1"
     xml2js "^0.4.19"
 
-"@azure/ms-rest-js@^2.0.4", "@azure/ms-rest-js@^2.5.1":
+"@azure/ms-rest-js@^2.0.4":
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.5.3.tgz#20477408b931c37deebb369e0c718093eee2649e"
   integrity sha512-OZ7qJwazS2nSRtZOA6+0k7x+RJ9D2P0IyUl9iHycyjgtQlINALNRutGqQeBirhIEx2IRQs9TMnnxoh/yRkFEAw==
@@ -239,6 +239,21 @@
     abort-controller "^3.0.0"
     form-data "^2.5.0"
     node-fetch "^2.6.0"
+    tough-cookie "^3.0.1"
+    tslib "^1.10.0"
+    tunnel "0.0.6"
+    uuid "^8.3.2"
+    xml2js "^0.4.19"
+
+"@azure/ms-rest-js@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.6.4.tgz#b0a0f89841434471adf757d09e7e39e8ecfcd650"
+  integrity sha512-2sbOpGhlBfv9itWdF7Qlk0CmoQCARxe5unwjNOprU7OdgEgabQncZ35L5u1A+zgdkVtNYF9Eo6XAhXzTweIhag==
+  dependencies:
+    "@azure/core-auth" "^1.1.4"
+    abort-controller "^3.0.0"
+    form-data "^2.5.0"
+    node-fetch "^2.6.7"
     tough-cookie "^3.0.1"
     tslib "^1.10.0"
     tunnel "0.0.6"
@@ -7367,6 +7382,13 @@ node-fetch@^2.1.1, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -10284,6 +10306,14 @@ whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
   integrity sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about these changes' context. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as if you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
See commit list

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Azure API Management may fail to create too many subscriptions for the same account. According to Microsoft support, this is due to its internal optimistic consistency mechanism. Such failures do not depend on us or on a specific traffic pattern and are non-deterministic from our perspective; nevertheless, they are treated as generic server errors 500 and are hard to be monitored apart and react to differently.

To improve our users' experience we decided to:
* retry up to 3 times on the `subscriptions.createOrUpdate` operation when a 412 error is returned, so our users do not have to care about anything at the cost of a slightly-higher response time
* respond with 429 if retries do not solve, so that they can regulate request rate themselves (it will also be helpful for us as we can better monitor failures)



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes from a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
