### PR TITLE
[#IOPAE-431] Delete cmsTag field before updating a service

### DIFF
--- a/UpdateService/handler.ts
+++ b/UpdateService/handler.ts
@@ -87,6 +87,15 @@ export function UpdateServiceHandler(
 
     const existingService = maybeService.value;
 
+    /* 
+    The new io-services-cms has a functionality to sync back and forth the services between the new and the legacy containers:
+     - when a service is created/updated using the new APIs it is also written into the legacy container and marked with a field "cmsTag"
+     - when a service is created/updated using the old APIs a CosmosDBTrigger Azure Function will intercept it an write it into the new container but 
+     only if the "cmsTag" field is not present, so when a service is updated using the old APIs the "cmsTag" field needs to be removed.
+    */
+    // eslint-disable-next-line fp/no-delete, functional/immutable-data, @typescript-eslint/dot-notation
+    delete existingService["cmsTag"];
+
     const errorOrUpdatedService = await serviceModel.update({
       ...existingService,
       ...apiServiceToService(servicePayload)

--- a/__mocks__/mocks.ts
+++ b/__mocks__/mocks.ts
@@ -136,6 +136,11 @@ export const aRetrievedService: RetrievedService = {
   version: 1 as NonNegativeInteger
 };
 
+export const aRetrievedServiceWithCmsTag: RetrievedService = {
+  ...aRetrievedService,
+  cmsTag: "cmsTag"
+} as RetrievedService;
+
 export const aSeralizedService: ApiService = {
   ...aServicePayload,
   id: "MySubscriptionId" as NonEmptyString,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The new `io-services-cms` has a functionality to sync back and forth the services between the new and the legacy containers:

- When a service is created/updated using the new APIs it is also written into the legacy container and marked with a field `cmsTag`
- When a service is created/updated using the old APIs a CosmosDBTrigger Azure Function will intercept it an write it into the new container but 
     only if the `cmsTag` field is not present, so when a service is updated using the old APIs the "cmsTag" field needs to be removed.
#### List of Changes
<!--- Describe your changes in detail -->
- Remove `cmsTag` before updating a service
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
